### PR TITLE
Docs section: keep the current section when switch between versions

### DIFF
--- a/app/Documentation.php
+++ b/app/Documentation.php
@@ -67,4 +67,17 @@ class Documentation {
 		});
 	}
 
+	/**
+	 * Check if the given section exists.
+	 *
+	 * @param  string  $version
+	 * @param  string  $page
+	 * @return boolean
+	 */
+	public function sectionExists($version, $page)
+	{
+		$path = base_path('resources/docs/'.$version.'/'.$page.'.md');
+		return $this->files->exists($path);
+	}
+
 }

--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -45,6 +45,11 @@ class DocsController extends Controller {
 
 		$content = $this->docs->get($version, $page ?: 'installation');
 
+		$section = '';
+		if ( $this->docs->sectionExists($version, $page)) {
+			$section .= '/' . $page;
+		}
+
 		if (is_null($content)) {
 			abort(404);
 		}
@@ -54,6 +59,7 @@ class DocsController extends Controller {
 			'content' => $content,
 			'currentVersion' => $version,
 			'versions' => $this->getDocVersions(),
+			'currentSection' => $section,
 		]);
 	}
 

--- a/resources/views/partials/switcher.blade.php
+++ b/resources/views/partials/switcher.blade.php
@@ -8,7 +8,7 @@
 		<ul class="dropdown-menu" role="menu" aria-labelledby="dropdownMenu1">
 			@foreach ($versions as $key => $display)
 				<li role="presentation">
-					<a role="menuitem" tabindex="-1" href="{{ url('docs/'.$key) }}">{{ $display }}</a>
+					<a role="menuitem" tabindex="-1" href="{{ url('docs/'.$key.$currentSection) }}">{{ $display }}</a>
 				</li>
 			@endforeach
 		</ul>


### PR DESCRIPTION
Hey, well basically, the idea is when you are located in the docs section.
You are reading in some specific section, e.g http://laravel.com/docs/4.2/homestead and you want to switch to another version such 5.0, it redirects you to http://laravel.com/docs/5.0

What I consider is that it should keep the section (in this example, homestead) with the new version selected (http://laravel.com/docs/5.0/homestead)

What do you think?

cc @GrahamCampbell 

![screen shot 2015-02-04 at 9 03 16 pm](https://cloud.githubusercontent.com/assets/3170758/6054371/cda2a15e-acb1-11e4-923c-5437f12fe87c.png)
![screen shot 2015-02-04 at 9 03 31 pm](https://cloud.githubusercontent.com/assets/3170758/6054372/d35ca658-acb1-11e4-965b-e6f09dbb9e21.png)
