### PR TITLE
Display the current page in the title

### DIFF
--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -51,6 +51,7 @@ class DocsController extends Controller {
 
 		return view('docs', [
 			'index' => $this->docs->getIndex($version),
+			'title' => ucfirst($page),
 			'content' => $content,
 			'currentVersion' => $version,
 			'versions' => $this->getDocVersions(),

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -2,7 +2,7 @@
 <html>
 <head>
 	<meta charset="utf-8">
-	<title>Laravel - The PHP Framework For Web Artisans</title>
+	<title>{{ isset($title) && !empty($title) ? $title . ' - ' : '' }}Laravel - The PHP Framework For Web Artisans</title>
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
 	<meta name="author" content="Taylor Otwell">
 	<meta name="description" content="Laravel - The PHP framework for web artisans.">


### PR DESCRIPTION
Display the title of current page in the docs. It helps when there are multiple tabs open.

Possible Errors:
- The page names don't always match the title in the sidebar