### PR TITLE
Fixed flash of unstyled content before dom ready in slide-menu.scss

### DIFF
--- a/public/assets/css/laravel.css
+++ b/public/assets/css/laravel.css
@@ -384,7 +384,7 @@ blockquote {
   white-space: nowrap;
   padding: 6px 12px;
   font-size: 14px;
-  line-height: 1.42857;
+  line-height: 1.42857143;
   border-radius: 4px;
   -webkit-user-select: none;
   -moz-user-select: none;
@@ -561,7 +561,7 @@ blockquote {
 .btn-lg {
   padding: 10px 16px;
   font-size: 18px;
-  line-height: 1.33333;
+  line-height: 1.3333333;
   border-radius: 6px; }
 
 .btn-sm {
@@ -666,7 +666,7 @@ tbody.collapse.in {
   padding: 3px 20px;
   clear: both;
   font-weight: normal;
-  line-height: 1.42857;
+  line-height: 1.42857143;
   color: #333333;
   white-space: nowrap; }
 
@@ -709,7 +709,7 @@ tbody.collapse.in {
   display: block;
   padding: 3px 20px;
   font-size: 12px;
-  line-height: 1.42857;
+  line-height: 1.42857143;
   color: #777777;
   white-space: nowrap; }
 
@@ -975,7 +975,8 @@ pre.line-numbers > code {
 
 .slide-menu {
   background: #f4645f;
-  padding: 0 20px; }
+  padding: 0 20px;
+  left: -70%; }
   .slide-menu h2 {
     color: #fff;
     font-weight: normal; }

--- a/resources/assets/sass/components/_slide-menu.scss
+++ b/resources/assets/sass/components/_slide-menu.scss
@@ -4,6 +4,7 @@
     // left: -250px;
     // width: 250px;
     padding: 0 20px;
+    left: -70%;
     // overflow: scroll;
     // z-index: 5;
     


### PR DESCRIPTION
Here's a screenshot of the flash of unstyled content happening before dom ready:
![](https://cloud.githubusercontent.com/assets/2265232/6178524/6c17cbf4-b318-11e4-8350-80887a76e843.png)