### PR TITLE
Add padding to nav links to make it "more clickable"

### DIFF
--- a/resources/assets/sass/components/_nav.scss
+++ b/resources/assets/sass/components/_nav.scss
@@ -32,6 +32,7 @@ nav.main {
 				line-height: 90px;
 				font-size: 16px;
 				color: $color__gray;
+				padding: 35px 0;
 				&:hover {
 					color: $color__salmon;
 				}


### PR DESCRIPTION
Added paddings to navbar links to be more user-friendly and easy clickable.

#### Before:
![before](https://cloud.githubusercontent.com/assets/1139050/7798672/cf3cb092-030d-11e5-8e08-c3a93a0402b0.gif)

#### After:
![after](https://cloud.githubusercontent.com/assets/1139050/7798675/d757d46e-030d-11e5-92c2-2bb88543407b.gif)
