### PR TITLE
add apple touch icon link to site

### DIFF
--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -12,6 +12,7 @@
 		<script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
 	<![endif]-->
 	<link rel="stylesheet" href="{{ elixir('assets/css/laravel.css') }}">
+	<link rel="apple-touch-icon" href="/favicon.png">
 </head>
 <body class="@yield('body-class', 'docs') language-php">
 


### PR DESCRIPTION
I like to have a link to the docs on my phone, but it currently just shows a screenshot of the site, and doesn't let you select a custom icon.

this commit tells IOS to use the logo image when people add any laravel.com page to their home screen.