### PR TITLE
Remove font smoothing

### DIFF
--- a/resources/assets/sass/core/_base.scss
+++ b/resources/assets/sass/core/_base.scss
@@ -11,7 +11,6 @@ body {
 	font-size: 16px;
 	background: #fff url('/assets/img/cloud-bar.png') repeat-x;
 	padding-top: 10px;
-	-webkit-font-smoothing: antialiased;
 }
 
 // h1, h2, h3, h4, h5, h6, p {


### PR DESCRIPTION
The font smoothing makes it very hard to read. Specially since the text is very thin to begin with. 

![antialised](https://cloud.githubusercontent.com/assets/499192/9106799/24cf9b02-3c23-11e5-9c48-2c14749e4eb0.jpg)

The above example show how it looked before this PR and after. Font smoothing makes mare sense with a dark background and bright font but the other way around just makes it harder to read. I guess it depends on the use case.