### PR TITLE
Fixes clearing the search

### DIFF
--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -112,7 +112,7 @@ $(function() {
     });
 
     $('#cross').click(function() {
-      typeahead.val('').keyup();
+      typeahead.typeahead('val', '').keyup();
       $article.css('opacity', '1');
     });
   }


### PR DESCRIPTION
`typeahead.js` has its own value store so clearing the value (`val()`) of the input is only aesthetic. This clears the input correctly and the search icon will now reappear after clicking the X cross.