### PR TITLE
Configure remote repository for Sami API documentation

### DIFF
--- a/build/sami/sami.php
+++ b/build/sami/sami.php
@@ -5,6 +5,7 @@ require __DIR__.'/../../vendor/autoload.php';
 use Sami\Sami;
 use Symfony\Component\Finder\Finder;
 use Sami\Version\GitVersionCollection;
+use Sami\RemoteRepository\GitHubRemoteRepository;
 
 $iterator = Finder::create()
 	->files()
@@ -23,4 +24,5 @@ return new Sami($iterator, array(
 	'build_dir' => __DIR__.'/build/%version%',
 	'cache_dir' => __DIR__.'/cache/%version%',
 	'default_opened_level' => 2,
+	'remote_repository' => new GitHubRemoteRepository('laravel/framework', dirname($dir)),
 ));


### PR DESCRIPTION
This adds "View source" links for every class (FriendsOfPHP/Sami#91):
![view-source](https://cloud.githubusercontent.com/assets/2457311/10710257/c20069e0-7a50-11e5-9a83-26f3168968c5.png)

In a future version of Sami each class method will get a link, too
(FriendsOfPHP/Sami#186):
![link](https://cloud.githubusercontent.com/assets/2457311/10710253/a937c944-7a50-11e5-990d-e2b6907f7b8c.png)
