### PR TITLE
added "word-break" CSS property to inline code

### DIFF
--- a/resources/assets/sass/components/_prism.scss
+++ b/resources/assets/sass/components/_prism.scss
@@ -74,6 +74,7 @@ pre[class*="language-"] {
 :not(pre) > code[class*="language-"] {
 	background: $color__faint;
 	color: $color__salmon;
+	word-break: break-word;
 	padding: 1px 5px;
 	border-radius: 3px;
 }


### PR DESCRIPTION
**long inline code breaks the layout**

![Screenshot of long inline code breaking the layout](https://cloud.githubusercontent.com/assets/13810696/12073483/3f4455c2-b149-11e5-8b0f-ca638e296289.jpg)