### PR TITLE
[5.2] Added “word-break” CSS property to inline code

### DIFF
--- a/resources/assets/sass/components/_prism.scss
+++ b/resources/assets/sass/components/_prism.scss
@@ -78,6 +78,10 @@ pre[class*="language-"] {
 	border-radius: 3px;
 }
 
+.token.package {
+	word-break: break-word;
+}
+
 .token.comment,
 .token.prolog,
 .token.doctype,


### PR DESCRIPTION
**long inline code breaks the layout**

![issue](https://cloud.githubusercontent.com/assets/13810696/12102638/1e550760-b362-11e5-9bc7-dc12dea0e180.jpg)

![solution_1](https://cloud.githubusercontent.com/assets/13810696/12102650/2fc6130e-b362-11e5-9651-0e703bbc3146.jpg)

![solution_2](https://cloud.githubusercontent.com/assets/13810696/12102659/3ad44e5a-b362-11e5-9306-ebbf10c34809.jpg)

**This PR is the above-mentioned Solution 2.**