### PR TITLE
Use canonical when possible

### DIFF
--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -48,7 +48,8 @@ class DocsController extends Controller {
 			define('CURRENT_VERSION', $version);
 		}
 
-		$content = $this->docs->get($version, $page ?: 'installation');
+		$sectionPage = $page ?: 'installation';
+		$content = $this->docs->get($version, $sectionPage);
 
 		if (is_null($content)) {
 			abort(404);
@@ -65,8 +66,8 @@ class DocsController extends Controller {
 		}
 
 		$canonical = null;
-		if ($this->docs->sectionExists(DEFAULT_VERSION, $page ?: 'installation')) {
-			$canonical = 'docs/'.DEFAULT_VERSION.'/'.($page ?: 'installation');
+		if ($this->docs->sectionExists(DEFAULT_VERSION, $sectionPage)) {
+			$canonical = 'docs/'.DEFAULT_VERSION.'/'.$sectionPage;
 		}
 
 		return view('docs', [

--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -64,6 +64,11 @@ class DocsController extends Controller {
 			return redirect('/docs/'.$version);
 		}
 
+		$canonical = null;
+		if ($this->docs->sectionExists(DEFAULT_VERSION, $page ?: 'installation')) {
+			$canonical = 'docs/'.DEFAULT_VERSION.'/'.$page;
+		}
+
 		return view('docs', [
 			'title' => count($title) ? $title->text() : null,
 			'index' => $this->docs->getIndex($version),
@@ -71,6 +76,7 @@ class DocsController extends Controller {
 			'currentVersion' => $version,
 			'versions' => Documentation::getDocVersions(),
 			'currentSection' => $section,
+			'canonical' => $canonical,
 		]);
 	}
 

--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -66,7 +66,7 @@ class DocsController extends Controller {
 
 		$canonical = null;
 		if ($this->docs->sectionExists(DEFAULT_VERSION, $page ?: 'installation')) {
-			$canonical = 'docs/'.DEFAULT_VERSION.'/'.$page;
+			$canonical = 'docs/'.DEFAULT_VERSION.'/'.($page ?: 'installation');
 		}
 
 		return view('docs', [

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -9,7 +9,7 @@
 	<meta name="keywords" content="laravel, php, framework, web, artisans, taylor otwell">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
-	@if (isset($canonical) && $canonical)
+	@if (isset($canonical))
 	<link rel="canonical" href="{{ url($canonical) }}" />
 	@elseif (defined('CURRENT_VERSION') && in_array(CURRENT_VERSION, ['master', '5.1', '5.0', '4.2']))
 	<meta name="robots" content="noindex">

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -9,8 +9,10 @@
 	<meta name="keywords" content="laravel, php, framework, web, artisans, taylor otwell">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 
-	@if (defined('CURRENT_VERSION') && in_array(CURRENT_VERSION, ['master', '5.1', '5.0', '4.2']))
-
+	@if (isset($canonical) && $canonical)
+	<link rel="canonical" href="{{ url($canonical) }}" />
+	@elseif (defined('CURRENT_VERSION') && in_array(CURRENT_VERSION, ['master', '5.1', '5.0', '4.2']))
+	<meta name="robots" content="noindex">
 	@endif
 
 	<!--[if lte IE 9]>


### PR DESCRIPTION
If the page hasn't changed, point the canonical link to the latest version, to keep the search rank. Only if no same page is found, use the no-index. (Re https://twitter.com/taylorotwell/status/762380829800538113 )

(Could be improved with mapping old->new, but it tedious to keep in sync perhaps).
/cc @casperbakker
