### PR TITLE
Tweak Search input field

### DIFF
--- a/resources/assets/sass/components/_nav.scss
+++ b/resources/assets/sass/components/_nav.scss
@@ -63,25 +63,26 @@ nav.main {
         svg { margin-right: 15px; }
 
         .twitter-typeahead {
-          height:     100%;
-          width:      100%;
-          direction:  ltr;
-          display:    inline-block;
-          position:   relative;
+            height:     100%;
+            width:      100%;
+            direction:  ltr;
+            display:    inline-block;
+            position:   relative;
 
-          input {
-              display: inline-block;
-              border: none;
-              flex: 1;
-              height: 100% !important;
-              &:focus { outline: none; }
-          }
-          input::placeholder {
-              font-family: $font_alt;
-              font-size: 12px;
-              text-transform: uppercase;
-              letter-spacing: 3px;
-          }
+            input {
+                display: inline-block;
+                border: none;
+                flex: 1;
+                height: 100% !important;
+                &:focus { outline: none; }
+
+                &::placeholder {
+                    font-family: $font_alt;
+                    font-size: 12px;
+                    text-transform: uppercase;
+                    letter-spacing: 3px;
+                }
+            }
         }
     }
 

--- a/resources/assets/sass/components/_nav.scss
+++ b/resources/assets/sass/components/_nav.scss
@@ -62,17 +62,26 @@ nav.main {
 
         svg { margin-right: 15px; }
 
-        input {
-            border: none;
-            flex: 1;
-            height: 50%;
-            &:focus { outline: none; }
-        }
-        input::placeholder {
-            font-family: $font_alt;
-            font-size: 12px;
-            text-transform: uppercase;
-            letter-spacing: 3px;
+        .twitter-typeahead {
+          height:     100%;
+          width:      100%;
+          direction:  ltr;
+          display:    inline-block;
+          position:   relative;
+
+          input {
+              display: inline-block;
+              border: none;
+              flex: 1;
+              height: 100% !important;
+              &:focus { outline: none; }
+          }
+          input::placeholder {
+              font-family: $font_alt;
+              font-size: 12px;
+              text-transform: uppercase;
+              letter-spacing: 3px;
+          }
         }
     }
 


### PR DESCRIPTION
Tweak Search input field for better usability by a bigger click area.

Used .twitter-typeahead class, but would be nice if we find a way to change the Typeahead wrapper for a more general class name.