### PR TITLE
Add highlighting of current page link in docs

### DIFF
--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -167,4 +167,12 @@ $(function() {
       $article.css('opacity', '1');
     });
   }
+
+  if ($('.sidebar ul').length) {
+    var current = $('.sidebar ul').find('li a[href="' + window.location.pathname + '"]');
+
+    if (current.length) {
+      current.parent().css('font-weight', 'bold');
+    }
+  }
 });


### PR DESCRIPTION
As far as I can tell, because the documentation index is cached, doing this client-side via JavaScript is the simplest way of implementing request at laravel/docs#2738
