### PR TITLE
Use custom local code font when available

### DIFF
--- a/resources/assets/sass/components/_prism.scss
+++ b/resources/assets/sass/components/_prism.scss
@@ -16,7 +16,7 @@ code[class*="language-"],
 pre[class*="language-"] {
 	color: black;
 	text-shadow: 0 1px white;
-	font-family: Consolas, Monaco, 'Andale Mono', monospace;
+	font-family: $font_code;
 	direction: ltr;
 	text-align: left;
 	white-space: pre;
@@ -203,7 +203,7 @@ pre.line-numbers > code {
 	pre[class*="language-"] {
 		color: #f8f8f2;
 		text-shadow: 0 1px rgba(0, 0, 0, 0.3);
-		font-family: Consolas, Monaco, 'Andale Mono', monospace;
+		font-family: $font_code;
 		direction: ltr;
 		text-align: left;
 		white-space: pre;

--- a/resources/assets/sass/core/_settings.scss
+++ b/resources/assets/sass/core/_settings.scss
@@ -13,3 +13,4 @@ $color__teal:           #27b4a8;
 
 $font:         'Source Sans Pro', sans-serif;
 $font_alt:     'Miriam Libre', 'Source Sans Pro', sans-serif;
+$font_code:    'Operator Mono', 'Fira Code', Consolas, Monaco, 'Andale Mono', monospace;


### PR DESCRIPTION
Use `Operator Mono` or `Fira Code` if it's available on the user's system.