### PR TITLE
added missing slide menu to 404 page

### DIFF
--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -5,7 +5,20 @@ the-404
 @endsection
 
 @section('content')
-	
+	<nav id="slide-menu" class="slide-menu" role="navigation">
+
+        <div class="brand">
+            <a href="/">
+                <img src="/assets/img/laravel-logo-white.png" height="50" alt="Laravel white logo">
+            </a>
+        </div>
+
+        <ul class="slide-main-nav">
+            @include('partials.main-nav')
+        </ul>
+
+    </nav>
+
 	<div class="contain">
 		<div class="media">
 			<img src="/assets/img/lamp-post.jpg">


### PR DESCRIPTION
On mobile, the menu icon does not trigger the slide menu on the 404 page specifically. I noticed that the scotchPanel is referencing the `#slide-menu` element, which appears to be missing in the template. I copied the nav section from the marketing and docs template.