### PR TITLE
Vertical align hash sign

### DIFF
--- a/resources/assets/sass/content/_docs.scss
+++ b/resources/assets/sass/content/_docs.scss
@@ -66,7 +66,6 @@
 			margin-left: -25px;
 			position: absolute;
 			font-size: 28px;
-			top: 5px;
 			color: $color__salmon;
 			opacity: .6;
 		}


### PR DESCRIPTION
Now the hash sign is below the title, which looks not so nice in my opinion, I suggest removing the top positioning so that this sign is aligned vertically.

Before:
![image](https://cloud.githubusercontent.com/assets/4408379/25404266/e465b28e-2a07-11e7-9aa8-c87d205c1127.png)

After:
![image](https://cloud.githubusercontent.com/assets/4408379/25404286/facdc46c-2a07-11e7-8c72-c7b2edfc59fe.png)

