### PR TITLE
Fix positioning for community dropdown

### DIFF
--- a/resources/assets/sass/components/_nav.scss
+++ b/resources/assets/sass/components/_nav.scss
@@ -94,7 +94,7 @@ nav.main {
 	}
 
     .community-dropdown .dropdown-menu {
-		top: 150%;
+		top: 100%;
         right: 0;
         left: auto;
 	}


### PR DESCRIPTION
Before:
![image](https://cloud.githubusercontent.com/assets/4408379/25446143/42ea4110-2ab9-11e7-96de-4fb7aac405ff.png)

After:
![image](https://cloud.githubusercontent.com/assets/4408379/25446174/5392340a-2ab9-11e7-8b00-326d30c5d04a.png)
