### PR TITLE
Fixed search key binding

### DIFF
--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -96,7 +96,7 @@ $(function() {
 
   Mousetrap.bind('/', function(e) {
     $('#search-input').focus();
-  }, 'keyup');
+  });
 
   initAlgoliaSearch();
 


### PR DESCRIPTION
With the `'keyup'` option specified, the key binding doesn't work very well with non-american (?) keyboard layouts where you have to press `Shift + 7` to get the `/` character. Simply removing the "keyup" option fixes the issue.