### PR TITLE
Prevent "/" from being typed

### DIFF
--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -95,6 +95,7 @@ $(function() {
   });
 
   Mousetrap.bind('/', function(e) {
+    e.preventDefault();
     $('#search-input').focus();
   });
 


### PR DESCRIPTION
So, it seems #121 introduced a bug which causes "/" to being typed into the search field at initial focus. 😳  

Calling `preventDefault` on the keyboard event fixes the issue.