### PR TITLE
[Bug Fix] Prevents mobile menu flash on page load

### DIFF
--- a/resources/assets/sass/components/_slide-menu.scss
+++ b/resources/assets/sass/components/_slide-menu.scss
@@ -2,7 +2,14 @@
 	background: $color__salmon;
     padding: 0 20px;
     left: -70%;
-    display: none !important;
+
+    @media (min-width: 959px) {
+        display: none;
+    }
+
+    &:not(.scotch-panel-left) {
+        display: none;
+    }
 
     h2 {
         position: relative;
@@ -63,12 +70,6 @@
 
 .wrap {
     position: relative;
-}
-
-@media (max-width: 960px) {
-    .slide-menu {
-        display: block !important;
-    }
 }
 
 .overlay {


### PR DESCRIPTION
This PR comes from the original https://github.com/laravel/laravel.com/pull/123/ 

It specifically focuses on fixing the mobile menu flash by implementing a mobile first css structure

![6847330e-3816-11e7-9e54-38697e63f084](https://cloud.githubusercontent.com/assets/1094740/26032183/a975e618-3884-11e7-83be-3d06b801cad1.gif)
