### PR TITLE
[Bug Fix] FOUC for search box whilst page is loading

### DIFF
--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -26,6 +26,10 @@ new Vue({
 
 
 jQuery(function($) {
+
+  // Fixes FOUC for the search box
+  $('.search.invisible').removeClass('invisible');
+
   // Smooth scroll to anchor
   $('body.home a[href*=#]:not([href=#])').click(function() {
     if (location.pathname.replace(/^\//,'') === this.pathname.replace(/^\//,'') && location.hostname == this.hostname) {

--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -27,9 +27,6 @@ new Vue({
 
 jQuery(function($) {
 
-  // Fixes FOUC for the search box
-  $('.search.invisible').removeClass('invisible');
-
   // Smooth scroll to anchor
   $('body.home a[href*=#]:not([href=#])').click(function() {
     if (location.pathname.replace(/^\//,'') === this.pathname.replace(/^\//,'') && location.hostname == this.hostname) {
@@ -118,6 +115,9 @@ jQuery(function($) {
   });
 
   initAlgoliaSearch();
+
+  // Fixes FOUC for the search box
+  $('.search.invisible').removeClass('invisible');
 
   function initAlgoliaSearch() {
     if (window.algolia_app_id === '') {

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -30,7 +30,7 @@
 			<span>Laravel</span>
 		</a>
 
-        <div class="search nav-block">
+        <div class="search nav-block invisible">
             {!! svg('search') !!}
             <input placeholder="search" type="text" v-model="search" id="search-input" v-on:blur="reset" />
         </div>


### PR DESCRIPTION
This is related to the list of changes https://github.com/laravel/laravel.com/pull/123

It specifically fixes a flash of un-styled content on the global site search box before algolia and typeahead have been initialised.

![fouc](https://cloud.githubusercontent.com/assets/1094740/26037347/136d5eca-38e9-11e7-84ac-38e5e4888d2e.gif)
