### PR TITLE
Keyboard shortcut added to expand all sections in the sidebar

### DIFF
--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -116,7 +116,7 @@ jQuery(function($) {
 
   Mousetrap.bind(["ctrl+b", "command+b"], function(e) {
     e.preventDefault();
-    $(".sidebar").find( "h2" ).toggleClass('is-active');
+    $(".sidebar").find( "h2" ).addClass('is-active');
   });
 
   initAlgoliaSearch();

--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -114,6 +114,11 @@ jQuery(function($) {
     $('#search-input').focus();
   });
 
+  Mousetrap.bind(["ctrl+b", "command+b"], function(e) {
+    e.preventDefault();
+    $(".sidebar").find( "h2" ).toggleClass('is-active');
+  });
+
   initAlgoliaSearch();
 
   // Fixes FOUC for the search box


### PR DESCRIPTION
As per [your suggestion](https://twitter.com/taylorotwell/status/871775692639264770) have added the shortcut since you have denied [our initial proposal](https://github.com/laravel/internals/issues/626)

- **`Ctrl+b`** or **`Command + b`** now expands all the sections in the docs sidebar.
- Decided on this particular shortcut since it's the closest to sublime's `ctrl+k+b` to open the sidebar but made it more shorter so it's more convenient.
- Open for further suggestions & discussion :blush: