### PR TITLE
Docs "Expand All" button with LocalStorage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ composer.phar
 .env
 .DS_Store
 Thumbs.db
+/.idea
+package-lock.json

--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -250,7 +250,7 @@ jQuery(function($) {
 
     // Modify states
     docCollapsed = !docCollapsed;
-    document.getElementById('doc-expand').text = (docCollapsed ? 'Expand' : 'Collapse') + " all";
+    document.getElementById('doc-expand').text = (docCollapsed ? 'Expand' : 'Collapse') + ' all';
 
     // Modify LS if we can
     if (storageAvailable('localStorage')) {
@@ -278,16 +278,15 @@ jQuery(function($) {
   document.getElementById('doc-expand') ? document.getElementById('doc-expand').addEventListener('click', expandDocs) : null;
 
   if ($('.sidebar ul').length) {
-    // If the doc is fully expanded, we don't need to toggle is-active for the current document
-    if(!docCollapsed) {
-      return;
-    }
-
     var current = $('.sidebar ul').find('li a[href="' + window.location.pathname + '"]');
 
     if (current.length) {
       current.parent().css('font-weight', 'bold');
-      current.closest('ul').prev().toggleClass('is-active');
+
+      // Only toggle the state if the user has collapsed the documentation
+      if(docCollapsed) {
+        current.closest('ul').prev().toggleClass('is-active');
+      }
     }
   }
 

--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -203,17 +203,7 @@ jQuery(function($) {
     });
   }
 
-  if ($('.sidebar ul').length) {
-    var current = $('.sidebar ul').find('li a[href="' + window.location.pathname + '"]');
-
-    if (current.length) {
-      current.parent().css('font-weight', 'bold');
-      current.closest('ul').prev().toggleClass('is-active');
-    }
-  }
-
   // collapse and expand for the sidebar
-
   var toggles = document.querySelectorAll('.sidebar h2'),
       togglesList = document.querySelectorAll('.sidebar h2 + ul');
 
@@ -257,7 +247,11 @@ jQuery(function($) {
         toggles[i].classList.remove('is-active')
       }
     }
+
+    // Modify states
     docCollapsed = !docCollapsed;
+    document.getElementById('doc-expand').text = (docCollapsed ? 'Expand' : 'Collapse') + " all";
+
     // Modify LS if we can
     if (storageAvailable('localStorage')) {
       localStorage.setItem('laravel_docCollapsed', docCollapsed);
@@ -282,6 +276,20 @@ jQuery(function($) {
 
   // Register event listener
   document.getElementById('doc-expand') ? document.getElementById('doc-expand').addEventListener('click', expandDocs) : null;
+
+  if ($('.sidebar ul').length) {
+    // If the doc is fully expanded, we don't need to toggle is-active for the current document
+    if(!docCollapsed) {
+      return;
+    }
+
+    var current = $('.sidebar ul').find('li a[href="' + window.location.pathname + '"]');
+
+    if (current.length) {
+      current.parent().css('font-weight', 'bold');
+      current.closest('ul').prev().toggleClass('is-active');
+    }
+  }
 
   function expandItem(e) {
     var elem = e.target;

--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -275,7 +275,7 @@ jQuery(function($) {
       localStorage.setItem('laravel_docCollapsed', true)
     } else {
       // Load previous state, and if it was false, then expand the doc
-      // LS will store only strings
+      // LS will store booleans as strings, we will "cast" them back here
       localStorage.getItem('laravel_docCollapsed') == 'false' ? expandDocs() : null
     }
   }

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -25,7 +25,7 @@
 
 	<section class="sidebar">
 		<script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=laravelcom" id="_carbonads_js"></script>
-
+		<small><a href="#" id="doc-expand">Expand All</a></small>
 		{!! $index !!}
 	</section>
 


### PR DESCRIPTION
As per your request: https://twitter.com/taylorotwell/status/882792854715854850

- Toggles classes of all headers to expand and collapse
- Saves state into LocalStorage if available (no polyfill but feature detection)
- Loads previous state if available
- Open for suggestions or edits to match code style 😄 

Small preview! https://static.ozairpatel.com/4g0go.mp4