### PR TITLE
Fix excessive spaces in code examples

### DIFF
--- a/resources/views/marketing.blade.php
+++ b/resources/views/marketing.blade.php
@@ -41,10 +41,10 @@ class Idea extends Eloquent
 	 *
 	 * @with Laravel
 	 */
-	 public function create()
-	 {
-	 	// Have a fresh start...
-	 }
+	public function create()
+	{
+		// Have a fresh start...
+	}
 
 }</code></pre>
             {!! svg('macbook') !!}
@@ -114,13 +114,13 @@ class Purchase implements ShouldQueue
 	/**
 	 * Purchase a new podcast.
 	 */
-	 public function handle(Repository $repo)
-	 {
-	 	foreach ($this->purchases as $purchase)
-	 	{
-	 		//
-	 	}
-	 }
+	public function handle(Repository $repo)
+	{
+		foreach ($this->purchases as $purchase)
+		{
+			//
+		}
+	}
 </code></pre>
 						</div>
 					</div>

--- a/resources/views/partials/browser.blade.php
+++ b/resources/views/partials/browser.blade.php
@@ -19,10 +19,10 @@ class Idea extends Eloquent
 	 *
 	 * @with Laravel
 	 */
-	 public function create()
-	 {
-	 	// Have a fresh start...
-	 }
+	public function create()
+	{
+		// Have a fresh start...
+	}
 
 }</code></pre>
 	</div>


### PR DESCRIPTION
I know it's a minor change, and you probably have a good reason to put it there. But I would definitely sleep better at night, knowing that I at least tried to fix it 😉 