### PR TITLE
Fix redeclare markdown() and DEFAULT_VERSION constant

### DIFF
--- a/bootstrap/helpers.php
+++ b/bootstrap/helpers.php
@@ -10,3 +10,11 @@ function svg($src)
 {
     return file_get_contents(public_path('assets/svg/' . $src . '.svg'));
 }
+
+/**
+ * Convert some text to Markdown...
+ */
+function markdown($text)
+{
+    return (new ParsedownExtra)->text($text);
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,14 +3,8 @@
 /**
  * Set the default documentation version...
  */
-define('DEFAULT_VERSION', '5.5');
-
-/**
- * Convert some text to Markdown...
- */
-function markdown($text)
-{
-    return (new ParsedownExtra)->text($text);
+if (! defined('DEFAULT_VERSION')) {
+    define('DEFAULT_VERSION', '5.5');
 }
 
 Route::get('/', function () {


### PR DESCRIPTION
When running a cache command like `config:cache` or `route:cache`, a fresh application will be created and `routes/web.php` will be included twice, then the command will fail.