### PR TITLE
Update Doc Expand element

### DIFF
--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -251,6 +251,7 @@ jQuery(function($) {
     // Modify states
     docCollapsed = !docCollapsed;
     document.getElementById('doc-expand').text = (docCollapsed ? '▶' : '▼');
+    document.getElementById('doc-expand').title = (docCollapsed ? 'Expand All' : 'Collapse All');
 
     // Modify LS if we can
     if (storageAvailable('localStorage')) {

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -25,7 +25,7 @@
 
 	<section class="sidebar">
 		<script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=laravelcom" id="_carbonads_js"></script>
-		<small><a href="#" id="doc-expand" style="font-size: 9px; color: #525252;">▶</a></small>
+		<small><a href="#" id="doc-expand" style="font-size: 9px; color: #525252;" title="Expand All">▶</a></small>
 		{!! $index !!}
 	</section>
 


### PR DESCRIPTION
A simple update, but I initially thought the `doc-expand` element was either part of the ad or the indicator for the active page that wasn't positioned properly.

Just added a default title for the element and updated the js to toggle along with the character.

**JS still needs minified**