### PR TITLE
Allow 4.2 docs to be updated

### DIFF
--- a/build/docs.sh
+++ b/build/docs.sh
@@ -2,6 +2,7 @@
 base=/home/forge/laravel.com
 docs=${base}/resources/docs
 
+cd ${docs}/4.2 && git pull origin 4.2
 cd ${docs}/5.0 && git pull origin 5.0
 cd ${docs}/5.1 && git pull origin 5.1
 cd ${docs}/5.2 && git pull origin 5.2


### PR DESCRIPTION
Currently, changes to the 4.2 docs do not get pulled into the Laravel.com website. PR examples include: #3388 (https://github.com/laravel/docs/commit/5d4c6621b09ca45c31754f86cac2a810ec081aad), #3328 (https://github.com/laravel/docs/commit/5f52dd18adb3ad9c126eb95abfa8ad7123c1b48e) and #2918 (https://github.com/laravel/docs/commit/d1daa182680ce2aafe3a7b81c442f3a2d744a980).

Also, the sidebar doesn't include the collapsable feature.