### PR TITLE
Prevent sidebar to be collapsed when hitting keys

### DIFF
--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -304,8 +304,11 @@ jQuery(function($) {
   }
 
   function expandItemKeyboard(e) {
-    clearItems();
     var elem = e.target;
+
+    if ([13, 37, 39].includes(e.keyCode)) {
+      clearItems();
+    }
 
     if (e.keyCode === 13) {
       elem.classList.toggle('is-active');


### PR DESCRIPTION
As some others pointed out [here](https://github.com/laravel/docs/issues/3277) and [here](https://github.com/laravel/docs/issues/3284), it's rather bothersome to not being able to cmd+click on sidebar menu links.

This pull request prevents the sidebar from collapsing when hitting keys that don't affect the sidebar (enter, left arrow, right arrow).