### PR TITLE
Force searchbox to be white

### DIFF
--- a/resources/assets/sass/components/_nav.scss
+++ b/resources/assets/sass/components/_nav.scss
@@ -74,6 +74,7 @@ nav.main {
             input {
                 display: inline-block;
                 border: none;
+                background: inherit;
                 flex: 1;
                 height: 100% !important;
                 &:focus { outline: none; }


### PR DESCRIPTION
I use a custom gtk theme under Ubuntu Mate. Styling from the gtk theme is applied  to the search box in Firefox. This PR forces the background of the search input to be white.

Before:

![before](https://user-images.githubusercontent.com/5840038/32983694-9e92d24c-cc90-11e7-8e21-c740000605ea.png)

After:

![after](https://user-images.githubusercontent.com/5840038/32983698-ad8cfa84-cc90-11e7-8645-3f07faa116ed.png)

