### PR TITLE
Smarter document 404s

### DIFF
--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -56,7 +56,15 @@ class DocsController extends Controller
         $content = $this->docs->get($version, $sectionPage);
 
         if (is_null($content)) {
-            abort(404);
+            return response()->view('docs', [
+                'title' => 'Page not found',
+                'index' => $this->docs->getIndex($version),
+                'content' => view('partials.doc-missing'),
+                'currentVersion' => $version,
+                'versions' => Documentation::getDocVersions(),
+                'currentSection' => '',
+                'canonical' => null,
+            ], 404);
         }
 
         $title = (new Crawler($content))->filterXPath('//h1');

--- a/resources/views/partials/doc-missing.blade.php
+++ b/resources/views/partials/doc-missing.blade.php
@@ -1,0 +1,3 @@
+<h1>Page not found</h1>
+<p>Sorry, but we could not find that document.</p>
+<p>Please choose an option from the menu on the left.</p>


### PR DESCRIPTION
Currently receiving a 404 on the documents page leaves you with no where to go. The common cause for receiving a 404 is switching Laravel document versions while looking at a specific page (which does not exist in the other version).

This is the current behavior:

![old](https://user-images.githubusercontent.com/1210658/36140059-453a0f5c-10e3-11e8-84c1-6e49d34716ca.gif)

As you can see - landing on the 404 page doesnt even give you a document option to choose from.

I propose to change it, so any document 404's are handled like this:

![new](https://user-images.githubusercontent.com/1210658/36140084-585d5fbc-10e3-11e8-8d64-6752cc65334a.gif)

At least this way you are able to access the menu of the Laravel version you just picked, rather than having to start from scratch.

Text could probably be tweaked slightly - but it's a starting point.

Normal 404 outside of the documents section are unchanged.