### PR TITLE
Smarter 404's version 2

### DIFF
--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -56,7 +56,15 @@ class DocsController extends Controller
         $content = $this->docs->get($version, $sectionPage);
 
         if (is_null($content)) {
-            abort(404);
+            return response()->view('docs', [
+                'title' => 'Page not found',
+                'index' => $this->docs->getIndex($version),
+                'content' => view('partials.doc-missing'),
+                'currentVersion' => $version,
+                'versions' => Documentation::getDocVersions(),
+                'currentSection' => '',
+                'canonical' => null,
+            ], 404);
         }
 
         $title = (new Crawler($content))->filterXPath('//h1');

--- a/resources/assets/sass/content/_404.scss
+++ b/resources/assets/sass/content/_404.scss
@@ -1,4 +1,4 @@
-body.the-404 .contain {
+.the-404 .contain {
 	@include clearfix;
 	padding: 50px 0;
 	display: table;
@@ -16,4 +16,8 @@ body.the-404 .contain {
 		display: table-cell;
 		vertical-align: middle;
 	}
+}
+
+.pl-6 {
+    padding-left: 1.5rem;
 }

--- a/resources/views/partials/doc-missing.blade.php
+++ b/resources/views/partials/doc-missing.blade.php
@@ -1,0 +1,3 @@
+<h1>Page not found</h1>
+<p>Sorry, but we could not find that document.</p>
+<p>Please choose an option from the menu on the left.</p>

--- a/resources/views/partials/doc-missing.blade.php
+++ b/resources/views/partials/doc-missing.blade.php
@@ -1,3 +1,10 @@
-<h1>Page not found</h1>
-<p>Sorry, but we could not find that document.</p>
-<p>Please choose an option from the menu on the left.</p>
+<div class="the-404">
+    <div class="contain">
+        <div class="media">
+            <img src="/assets/img/lamp-post.jpg">
+        </div>
+        <div class="content pl-6">
+            <h3>You seem to have upset the delicate internal balance of my housekeeper.</h3>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Ok - this is another attempt at smarter document 404's.

Now we just display the same 404 message, but with the doucment menu available.

**Current behavior:**
![current](https://user-images.githubusercontent.com/1210658/36182665-0e0f8896-116e-11e8-8989-3463e43d9b74.gif)

**New behavior:**
![new](https://user-images.githubusercontent.com/1210658/36182679-2546bcc8-116e-11e8-9850-645bca80868c.gif)

Original 404 page is unchanged for the rest of the site - it will display the same.