### PR TITLE
Use load() to register commands

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,8 +13,7 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        Commands\ClearPageCache::class,
-        Commands\IndexDocuments::class,
+        //
     ];
 
     /**
@@ -29,12 +28,12 @@ class Kernel extends ConsoleKernel
     }
 
     /**
-     * Register the Closure based commands for the application.
+     * Register the commands for the application.
      *
      * @return void
      */
     protected function commands()
     {
-        //
+        $this->load(__DIR__.'/Commands');
     }
 }


### PR DESCRIPTION
Register app commands using the `load()` method on the console kernel.