### PR TITLE
Fix Carbon Line Height

### DIFF
--- a/resources/assets/sass/laravel.scss
+++ b/resources/assets/sass/laravel.scss
@@ -31,12 +31,11 @@
 #carbonads {
   display: block;
   overflow: hidden;
-  margin-bottom: 1em;
-  padding: 1em;
+  margin-bottom: 20px;
+  padding: 14px 12px;
   border: dashed 1px #e6e6e6;
   text-align: center;
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: 12px;
 }
 
 #carbonads span {
@@ -46,17 +45,22 @@
 
 .carbon-img {
   display: block;
-  margin: 0 auto 1em;
+  margin: 0 auto 8px;
+  line-height: 1!important;
 }
 
 .carbon-text {
   display: block;
-  margin-bottom: .5em;
+  margin-bottom: 8px;
+  line-height: 1.7 !important;
 }
 
 .carbon-poweredby {
   display: block;
-  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: .5px;
+  font-size: 8px;
+  line-height: 1 !important;
 }
 
 .laracon-banner, .laracon-banner a, .laracon-banner a:visited {


### PR DESCRIPTION
Adjust the line-height and em value to make the Carbon ad more compact
and take less vertical space due to sidebar > li line-height is set to
30px.

Check out the preview at https://d.pr/i/OQ3zhj