### PR TITLE
New flag styling should apply only to partners

### DIFF
--- a/resources/assets/sass/content/_community.scss
+++ b/resources/assets/sass/content/_community.scss
@@ -219,7 +219,7 @@
     float: left;
 }
 
-.flag{
+.partners .flag{
     font-size: 30px;
     background: hsla(0, 0, 100%, 0.6);
     padding: 16px;


### PR DESCRIPTION
`.flag` is used elsewhere in the docs. Fixes https://github.com/laravel/docs/issues/4152.