### PR TITLE
Move the slide-menu into partials

### DIFF
--- a/resources/views/community-partner-64robots.blade.php
+++ b/resources/views/community-partner-64robots.blade.php
@@ -4,17 +4,7 @@
 
 @section('content')
 
-<nav id="slide-menu" class="slide-menu" role="navigation">
-    <div class="brand">
-        <a href="/">
-            <img src="/assets/img/laravel-logo-white.png" height="50" alt="Laravel white logo">
-        </a>
-    </div>
-
-    <ul class="slide-main-nav">
-        @include('partials.main-nav')
-    </ul>
-</nav>
+@include('partials.slide-menu')
 
 <section class="partner-profile">
     <div class="container">

--- a/resources/views/community-partner-byte5.blade.php
+++ b/resources/views/community-partner-byte5.blade.php
@@ -4,18 +4,7 @@
 
 @section('content')
 
-<nav id="slide-menu" class="slide-menu" role="navigation">
-    <div class="brand">
-        <a href="/">
-            <img src="/assets/img/laravel-logo-white.png" height="50" alt="Laravel white logo">
-        </a>
-    </div>
-
-    <ul class="slide-main-nav">
-        @include('partials.main-nav')
-    </ul>
-</nav>
-
+@include('partials.slide-menu')
 <section class="partner-profile">
     <div class="container">
         <a href="/partners"><h4>Laravel Partners</h4></a>

--- a/resources/views/community-partner-cubet.blade.php
+++ b/resources/views/community-partner-cubet.blade.php
@@ -4,18 +4,7 @@
 
 @section('content')
 
-<nav id="slide-menu" class="slide-menu" role="navigation">
-    <div class="brand">
-        <a href="/">
-            <img src="/assets/img/laravel-logo-white.png" height="50" alt="Laravel white logo">
-        </a>
-    </div>
-
-    <ul class="slide-main-nav">
-        @include('partials.main-nav')
-    </ul>
-</nav>
-
+@include('partials.slide-menu')
 <section class="partner-profile">
     <div class="container">
         <a href="/partners"><h4>Laravel Partners</h4></a>

--- a/resources/views/community-partner-kirschbaum.blade.php
+++ b/resources/views/community-partner-kirschbaum.blade.php
@@ -4,17 +4,7 @@
 
 @section('content')
 
-<nav id="slide-menu" class="slide-menu" role="navigation">
-    <div class="brand">
-        <a href="/">
-            <img src="/assets/img/laravel-logo-white.png" height="50" alt="Laravel white logo">
-        </a>
-    </div>
-
-    <ul class="slide-main-nav">
-        @include('partials.main-nav')
-    </ul>
-</nav>
+@include('partials.slide-menu')
 
 <section class="partner-profile">
     <div class="container">

--- a/resources/views/community-partner-tighten.blade.php
+++ b/resources/views/community-partner-tighten.blade.php
@@ -4,17 +4,7 @@
 
 @section('content')
 
-<nav id="slide-menu" class="slide-menu" role="navigation">
-    <div class="brand">
-        <a href="/">
-            <img src="/assets/img/laravel-logo-white.png" height="50" alt="Laravel white logo">
-        </a>
-    </div>
-
-    <ul class="slide-main-nav">
-        @include('partials.main-nav')
-    </ul>
-</nav>
+@include('partials.slide-menu')
 
 <section class="partner-profile">
     <div class="container">

--- a/resources/views/community-partner-vehikl.blade.php
+++ b/resources/views/community-partner-vehikl.blade.php
@@ -4,17 +4,7 @@
 
 @section('content')
 
-<nav id="slide-menu" class="slide-menu" role="navigation">
-    <div class="brand">
-        <a href="/">
-            <img src="/assets/img/laravel-logo-white.png" height="50" alt="Laravel white logo">
-        </a>
-    </div>
-
-    <ul class="slide-main-nav">
-        @include('partials.main-nav')
-    </ul>
-</nav>
+@include('partials.slide-menu')
 
 <section class="partner-profile">
     <div class="container">

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -1,25 +1,8 @@
 @extends('app')
 
 @section('content')
-<nav id="slide-menu" class="slide-menu" role="navigation">
 
-	<div class="brand">
-		<a href="/">
-			<img src="/assets/img/laravel-logo-white.png" height="50">
-		</a>
-	</div>
-
-	<ul class="slide-main-nav">
-		<li><a href="/">Home</a></li>
-		@include('partials.main-nav')
-	</ul>
-
-	<div class="slide-docs-nav">
-		<h2>Documentation</h2>
-		{!! $index !!}
-	</div>
-
-</nav>
+@include('partials.slide-menu', ['docs' => true])
 
 <div class="docs-wrapper container">
 

--- a/resources/views/errors/404.blade.php
+++ b/resources/views/errors/404.blade.php
@@ -5,17 +5,7 @@ the-404
 @endsection
 
 @section('content')
-    <nav id="slide-menu" class="slide-menu" role="navigation">
-        <div class="brand">
-            <a href="/">
-                <img src="/assets/img/laravel-logo-white.png" height="50" alt="Laravel white logo">
-            </a>
-        </div>
-
-        <ul class="slide-main-nav">
-            @include('partials.main-nav')
-        </ul>
-    </nav>
+    @include('partials.slide-menu')
 
     <div class="contain">
         <div class="media">

--- a/resources/views/marketing.blade.php
+++ b/resources/views/marketing.blade.php
@@ -4,19 +4,7 @@
 
 @section('content')
 
-<nav id="slide-menu" class="slide-menu" role="navigation">
-
-	<div class="brand">
-		<a href="/">
-			<img src="/assets/img/laravel-logo-white.png" height="50" alt="Laravel white logo">
-		</a>
-	</div>
-
-	<ul class="slide-main-nav">
-		@include('partials.main-nav')
-	</ul>
-
-</nav>
+@include('partials.slide-menu')
 
 <section class="hero">
 	<div class="container">

--- a/resources/views/partials/slide-menu.blade.php
+++ b/resources/views/partials/slide-menu.blade.php
@@ -1,0 +1,21 @@
+<nav id="slide-menu" class="slide-menu" role="navigation">
+    <div class="brand">
+        <a href="/">
+            <img src="/assets/img/laravel-logo-white.png" height="50" alt="Laravel white logo">
+        </a>
+    </div>
+
+    <ul class="slide-main-nav">
+        @if (!empty($docs))
+            <li><a href="/">Home</a></li>
+        @endif
+        @include('partials.main-nav')
+    </ul>
+
+    @if (!empty($docs))
+        <div class="slide-docs-nav">
+            <h2>Documentation</h2>
+            {!! $index !!}
+        </div>
+    @endif
+</nav>

--- a/resources/views/partners.blade.php
+++ b/resources/views/partners.blade.php
@@ -3,17 +3,8 @@
 @section('body-class', 'community')
 
 @section('content')
-    <nav id="slide-menu" class="slide-menu" role="navigation">
-        <div class="brand">
-            <a href="/">
-                <img src="/assets/img/laravel-logo-white.png" height="50" alt="Laravel white logo">
-            </a>
-        </div>
 
-        <ul class="slide-main-nav">
-            @include('partials.main-nav')
-        </ul>
-    </nav>
+@include('partials.slide-menu')
 
     <section class="hero">
         <div class="container">


### PR DESCRIPTION
Since the mobile slide-menu is repeated for every page, I moved it into partials. For the docs page, I send an `docs` parameter so the partials can render the documentation nav in the docs page.