### PR TITLE
Use array_key_exists

### DIFF
--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -102,6 +102,6 @@ class DocsController extends Controller
      */
     protected function isVersion($version)
     {
-        return in_array($version, array_keys(Documentation::getDocVersions()));
+        return array_key_exists($version, Documentation::getDocVersions());
     }
 }


### PR DESCRIPTION
Unless there is a reason for getting the array keys first, we should use the native PHP function for this.