### PR TITLE
Remove unused league/commonmark dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
     "require": {
         "php": ">=7.1.3",
         "laravel/framework": "5.6.*",
-        "league/commonmark": "0.7.*",
         "erusev/parsedown-extra": "0.7.0",
         "symfony/browser-kit": "~3.1",
         "vinkla/algolia": "~3.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "1f2890f7d47759e7a9fc640db2e55082",
+    "content-hash": "f6c4c6c55cbef38eb9ad13795d64eed2",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -566,65 +566,6 @@
                 "laravel"
             ],
             "time": "2018-02-09T13:33:22+00:00"
-        },
-        {
-            "name": "league/commonmark",
-            "version": "0.7.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "7fecb7bdef265e45c80c53e1000e2056a9463401"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/7fecb7bdef265e45c80c53e1000e2056a9463401",
-                "reference": "7fecb7bdef265e45c80c53e1000e2056a9463401",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": ">=5.3.3"
-            },
-            "replace": {
-                "colinodell/commonmark-php": "*"
-            },
-            "require-dev": {
-                "erusev/parsedown": "~1.0",
-                "jgm/commonmark": "0.18",
-                "michelf/php-markdown": "~1.4",
-                "phpunit/phpunit": "~4.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.8-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "League\\CommonMark\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Colin O'Dell",
-                    "email": "colinodell@gmail.com",
-                    "homepage": "http://www.colinodell.com",
-                    "role": "Lead Developer"
-                }
-            ],
-            "description": "Markdown parser for PHP based on the CommonMark spec",
-            "homepage": "https://github.com/thephpleague/commonmark",
-            "keywords": [
-                "commonmark",
-                "markdown",
-                "parser"
-            ],
-            "time": "2015-03-08T17:48:53+00:00"
         },
         {
             "name": "league/flysystem",


### PR DESCRIPTION
The league/commonmark package was previously swapped and replaced by erusev/parsedown-extra, but its dependency was never removed.

This PR is courtesy of @JeffreyWay and his new Laracasts' course on How to Read Code.