### PR TITLE
add prev and next article link

### DIFF
--- a/app/Documentation.php
+++ b/app/Documentation.php
@@ -119,4 +119,23 @@ class Documentation
             '4.2' => '4.2',
         ];
     }
+
+
+    public function getPrevSection($version, $sectionPage)
+    {
+        $index = $this->getIndex($version);
+
+        preg_match_all("/(\<a.*?\<\/a>.*)\n.+\/docs\/".$version."\/".preg_quote($sectionPage)."/", $index, $matches); 
+
+        return $matches[1]; 
+    }
+
+    public function getNextSection($version, $sectionPage)
+    {
+        $index = $this->getIndex($version);
+
+        preg_match_all("/\/docs\/".$version."\/".preg_quote($sectionPage)."[\s\S]*?(?=\n.*?\<a href=\"\/docs)[\s]+\<li\>(\<a.*?<\/a\>)/", $index, $matches);
+
+        return $matches[1]; 
+    }
 }

--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -83,6 +83,10 @@ class DocsController extends Controller
             $canonical = 'docs/'.DEFAULT_VERSION.'/'.$sectionPage;
         }
 
+        $prevLink = $this->docs->getPrevSection($version, $sectionPage);
+        $nextLink = $this->docs->getNextSection($version, $sectionPage);
+
+
         return view('docs', [
             'title' => count($title) ? $title->text() : null,
             'index' => $this->docs->getIndex($version),
@@ -91,6 +95,8 @@ class DocsController extends Controller
             'versions' => Documentation::getDocVersions(),
             'currentSection' => $section,
             'canonical' => $canonical,
+            'prevLink' => $prevLink, 
+            'nextLink' => $nextLink,
         ]);
     }
 

--- a/resources/assets/sass/content/_docs.scss
+++ b/resources/assets/sass/content/_docs.scss
@@ -331,6 +331,26 @@
 	overflow: hidden;
 }
 
+.nav_prev_next {
+	display: flex;
+	justify-content: space-between;
+	margin-top: 40px;
+	> span {
+		position: relative;
+		color: #f4645f;
+		:after {
+			position:absolute;
+			top:0;
+			right:0;
+			bottom:0;
+			left:0;
+			z-index:1;
+			pointer-events:auto;
+			content:"";
+		}
+	}
+}
+
 @media (max-width:1080px) {
 
 	.docs article {

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -38,6 +38,10 @@
 
 	<article>
 		{!! $content !!}
+		<nav aria-labelledby="helpdoc_prev_next" class="nav_prev_next">
+			<span>{!! $prevLink ? '< ' . $prevLink[0] : '' !!}</span>
+			<span>{!! $nextLink ? $nextLink[0] . ' >' : '' !!}</span>
+		</nav>
 	</article>
 </div>
 @endsection


### PR DESCRIPTION
I saw the someone requested this feature in Twitter and this PR will be easier to navigate to next and previous page of documents. 

I've added two methods in Documentation Model to get the relevant link with regex and it rely on existing getIndex to get lists of the links. 

This is my first PR to opensource, so if there is something that I am doing right, please don't hesitate to let me know. 
