### PR TITLE
Add docs version switcher to sub 500 px mobile screens

### DIFF
--- a/resources/assets/sass/components/_slide-menu.scss
+++ b/resources/assets/sass/components/_slide-menu.scss
@@ -28,23 +28,48 @@
         img { margin-left: -20px; }
     }
 
-    .slide-docs-nav > ul {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-        > li {
-            color: #fff;
-            font-size: 18px;
-            font-weight: 400;
+    .slide-docs-nav {
+        .switcher {
+            float: right;
+            margin-top: -0.75rem;
+
+            @media (min-width: 501px) {
+                display: none;
+            }
+
+            .btn {
+                background-color: #ffffff;
+                color: #262626;
+                &:hover,
+                &:active {
+                    background-color: #f5f5f5;
+                }
+            }
+
+            .dropdown-menu {
+                right: 0;
+                left: auto;
+            }
+        }
+
+        > ul {
+            list-style: none;
             padding: 0;
             margin: 0;
-            > ul {
-                border-top: 1px dashed rgba(0,0,0,.1);
-                list-style: none;
-                margin: 10px 0 0 0;
-                padding: 10px 0 0 0;
-                font-size: 13px;
-                line-height: 1.8;
+            > li {
+                color: #fff;
+                font-size: 18px;
+                font-weight: 400;
+                padding: 0;
+                margin: 0;
+                > ul {
+                    border-top: 1px dashed rgba(0,0,0,.1);
+                    list-style: none;
+                    margin: 10px 0 0 0;
+                    padding: 10px 0 0 0;
+                    font-size: 13px;
+                    line-height: 1.8;
+                }
             }
         }
     }

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -15,7 +15,13 @@
 	</ul>
 
 	<div class="slide-docs-nav">
-		<h2>Documentation</h2>
+		<h2>
+			@if (isset($currentVersion))
+				@include('partials.switcher')
+			@endif
+			
+			Documentation
+		</h2>
 		{!! $index !!}
 	</div>
 


### PR DESCRIPTION
Currently, the version switch in the Documentation section disappears on screens with a width of 500 pixels or fewer. As a result, it is not possible to view documentation for versions older than the current version, when viewing on most mobile screens.

This PR simply takes the existing version switcher functionality and adds it into the sidebar, for screens with a width of 500 pixels or fewer. The code changes to implement this are purposefully very simple, reusing the existing version switch code in full - with only slight style changes to account for positioning and the change in background color.

This PR only impacts the sidebar, of the Documentation section, when viewing from a device with 500 pixels or fewer width. All other parts of the site remain unchanged.

**<500px Docs Sidebar - Before**
<img width="397" alt="500px docs sidebar - before" src="https://user-images.githubusercontent.com/125735/46353681-ccb2dc00-c62a-11e8-8377-1004c5f51148.png">

**<500px Docs Sidebar - After**
<img width="398" alt="500px docs sidebar - after" src="https://user-images.githubusercontent.com/125735/46353760-f966f380-c62a-11e8-992b-ba0e06c766b7.png">

For your reference, I included the below screenshots to show how the site header drops the version switcher on <500px screen widths currently. This is done for a good reason, as there simply isn't enough room for it in the header (which is why I felt that adding it to the sidebar would make sense instead).

**>500px Docs Header with Version Switcher**
<img width="514" alt="500px docs header with version switcher" src="https://user-images.githubusercontent.com/125735/46353633-af7e0d80-c62a-11e8-9420-05471e99b4bb.png">

**<500px Docs Header, no version switcher**
<img width="401" alt="500px docs header no version switcher" src="https://user-images.githubusercontent.com/125735/46353654-bb69cf80-c62a-11e8-9938-95ef70481780.png">