### PR TITLE
Change mobile version switcher appearance for smallest screens

### DIFF
--- a/resources/assets/sass/components/_slide-menu.scss
+++ b/resources/assets/sass/components/_slide-menu.scss
@@ -29,10 +29,7 @@
     }
 
     .slide-docs-nav {
-        .switcher {
-            float: right;
-            margin-top: -0.75rem;
-
+        .slide-docs-version {
             @media (min-width: 501px) {
                 display: none;
             }
@@ -40,15 +37,12 @@
             .btn {
                 background-color: #ffffff;
                 color: #262626;
+                font-size: 13px;
+                padding: 6px 12px;
                 &:hover,
                 &:active {
                     background-color: #f5f5f5;
                 }
-            }
-
-            .dropdown-menu {
-                right: 0;
-                left: auto;
             }
         }
 

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -15,13 +15,22 @@
 	</ul>
 
 	<div class="slide-docs-nav">
-		<h2>
-			@if (isset($currentVersion))
-				@include('partials.switcher')
-			@endif
-			
-			Documentation
-		</h2>
+		<h2>Documentation</h2>
+
+		<ul class="slide-docs-version">
+			<li>
+				<h2>Version</h2>
+
+				<ul>
+					<li>
+						@if (isset($currentVersion))
+							@include('partials.switcher')
+						@endif
+					</li>
+				</ul>
+			</li>
+		</ul>
+
 		{!! $index !!}
 	</div>
 


### PR DESCRIPTION
The new version switcher that appear in the sidebar on <500px screens doesn't work well with the smallest screens, like an iPhone SE. This PR changes the appearance of the version switcher to fix this problem. I experimented with a few different ways of fixing this, and have settled on this as the best of the bunch.

<img width="400" alt="mobile version switcher" src="https://user-images.githubusercontent.com/125735/46422988-82e9f480-c703-11e8-9fc0-96f40a195f4a.png">

Note that I did experiment with simply showing all of the versions in a list, similar to the other doc sections, but I felt that was both too confusing and also took up too much vertical real estate.