### PR TITLE
Fix invalid version redirect

### DIFF
--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -45,7 +45,7 @@ class DocsController extends Controller
     public function show($version, $page = null)
     {
         if (! $this->isVersion($version)) {
-            return redirect('docs/'.DEFAULT_VERSION.'/'.$version, 301);
+            return redirect('docs/'.DEFAULT_VERSION.'/'.$page, 301);
         }
 
         if (! defined('CURRENT_VERSION')) {


### PR DESCRIPTION
Fixes redirect when invalid docs version is specified. For example, docs/4.1 was redirecting to docs/5.7/4.1. Also preserve requested page (i.e., docs/4.1/releases will properly go to docs/5.7/releases instead of docs/5.7/4.1)