### PR TITLE
Update the packages component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "private": true,
   "scripts": {
-      "dev": "npm run development",
-      "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-      "watch": "npm run development -- --watch",
-      "watch-poll": "npm run watch -- --watch-poll",
-      "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
-      "prod": "npm run production",
-      "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "dev": "npm run development",
+    "development": "cross-env NODE_ENV=development node_modules/webpack/bin/webpack.js --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "watch": "npm run development -- --watch",
+    "watch-poll": "npm run watch -- --watch-poll",
+    "hot": "cross-env NODE_ENV=development node_modules/webpack-dev-server/bin/webpack-dev-server.js --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "prod": "npm run production",
+    "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "devDependencies": {
     "cross-env": "^5.1",

--- a/public/assets/css/laravel.css
+++ b/public/assets/css/laravel.css
@@ -1926,6 +1926,8 @@ pre.line-numbers > code {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
+  -ms-flex-wrap: wrap;
+      flex-wrap: wrap;
 }
 
 .packages:after {
@@ -1934,19 +1936,31 @@ pre.line-numbers > code {
   clear: both;
 }
 
-.packages .third:not(:last-child) {
-  border-right: 2px solid #f0f1f3;
-}
-
-.packages .package {
-  margin-bottom: 30px;
+.packages .package-row {
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;
 }
 
-.packages .package:last-child {
-  margin-bottom: 0;
+.packages .package-row:last-child .package {
+  padding-bottom: 0;
+}
+
+.packages .package {
+  width: 33.33%;
+  margin-left: 15px;
+  margin-right: 15px;
+  padding-bottom: 30px;
+}
+
+.packages .package:not(:last-child) {
+  border-right: 2px solid #f0f1f3;
+}
+
+.packages .package {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .packages .package .package-title {
@@ -1979,27 +1993,17 @@ pre.line-numbers > code {
 }
 
 @media all and (max-width: 800px) {
-  .packages {
+  .packages .package-row {
     -ms-flex-wrap: wrap;
         flex-wrap: wrap;
   }
 
-  .packages .third {
-    border: none !important;
-  }
-
   .packages .package {
+    width: 100%;
+    border-right-width: 0 !important;
     border-bottom: 1px solid #f0f1f3;
-    padding-bottom: 15px;
-  }
-
-  .packages .package:last-child {
+    padding-bottom: 15px !important;
     margin-bottom: 30px;
-  }
-
-  .packages .last {
-    border: none;
-    margin-bottom: 0 !important;
   }
 }
 

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
     "/assets/js/laravel.js": "/assets/js/laravel.js?id=8f117ab66f097a179fb0",
-    "/assets/css/laravel.css": "/assets/css/laravel.css?id=8fb29f139274dfe0dc8d"
+    "/assets/css/laravel.css": "/assets/css/laravel.css?id=561f882931bf31d146e8"
 }

--- a/resources/assets/sass/components/_packages.scss
+++ b/resources/assets/sass/components/_packages.scss
@@ -1,14 +1,31 @@
-.packages { @include items; }
+.packages { 
+    @include items; 
+    flex-wrap: wrap;
+}
 
-.packages .third:not(:last-child) {
-    border-right: 2px solid #f0f1f3;
+.packages .package-row {
+    display: flex;
+
+    &:last-child {
+        .package {
+            padding-bottom: 0;
+        }
+    }
 }
 
 .packages .package {
-    margin-bottom: 30px;
-    display: flex;
+    width: 33.33%;
+    margin-left: 15px;
+    margin-right: 15px;
+    padding-bottom: 30px;
 
-    &:last-child { margin-bottom: 0; }
+    &:not(:last-child){
+        border-right: 2px solid #f0f1f3;
+    }
+}
+
+.packages .package {
+    display: flex;
 
     .package-title {
         color: #444;
@@ -33,18 +50,18 @@
     }
 }
 
+
 @media all and (max-width: 800px) {
     .packages {
-        flex-wrap: wrap;
-        .third { border: none !important; }
-        .package {
-            border-bottom: 1px solid #f0f1f3;
-            padding-bottom: 15px;
+        .package-row {
+            flex-wrap: wrap;
         }
-        .package:last-child { margin-bottom: 30px; }
-        .last {
-            border: none;
-            margin-bottom: 0 !important;
+        .package{
+            width: 100%;
+            border-right-width: 0 !important;
+            border-bottom: 1px solid #f0f1f3;
+            padding-bottom: 15px !important;
+            margin-bottom: 30px;
         }
     }
 }

--- a/resources/views/marketing.blade.php
+++ b/resources/views/marketing.blade.php
@@ -230,7 +230,7 @@ Route::get('/user/{user}', function(App\User $user)
                 <span class="text">And so much more!</span>
             </div>
             <div class="packages">
-                <div class="third">
+                <div class="package-row">
                     <div class="package">
                         <div class="icon">{!! svg('package') !!}</div>
                         <div class="content">
@@ -238,6 +238,23 @@ Route::get('/user/{user}', function(App\User $user)
                             <p>A Laravel development environment for Mac minimalists. No Vagrant, no Apache, no fuss.</p>
                         </div>
                     </div>
+                    <div class="package">
+                        <div class="icon">{!! svg('package') !!}</div>
+                        <div class="content">
+                            <a href="/docs/mix" class="package-title">Mix</a>
+                            <!-- <p>If you've ever been frustrated with Gulp and asset compilation, Elixir is for you.</p> -->
+                            <p>Laravel Mix makes front-end a breeze. Start using SASS and Webpack in minutes.</p>
+                        </div>
+                    </div>
+                    <div class="package">
+                        <div class="icon">{!! svg('package') !!}</div>
+                        <div class="content">
+                            <a href="https://lumen.laravel.com" class="package-title">Lumen</a>
+                            <p>If all you need is an API and lightning fast speed, try Lumen. It’s Laravel super-light.</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="package-row">
                     <div class="package">
                         <div class="icon">{!! svg('package') !!}</div>
                         <div class="content">
@@ -250,16 +267,6 @@ Route::get('/user/{user}', function(App\User $user)
                             @endif
                         </div>
                     </div>
-                </div>
-                <div class="third">
-                    <div class="package">
-                        <div class="icon">{!! svg('package') !!}</div>
-                        <div class="content">
-                            <a href="/docs/mix" class="package-title">Mix</a>
-                            <!-- <p>If you've ever been frustrated with Gulp and asset compilation, Elixir is for you.</p> -->
-                            <p>Laravel Mix makes front-end a breeze. Start using SASS and Webpack in minutes.</p>
-                        </div>
-                    </div>
                     <div class="package">
                         <div class="icon">{!! svg('package') !!}</div>
                         <div class="content">
@@ -267,16 +274,7 @@ Route::get('/user/{user}', function(App\User $user)
                             <p>Powerful SaaS application scaffolding. Stop writing boilerplate & focus on your application.</p>
                         </div>
                     </div>
-                </div>
-                <div class="third">
                     <div class="package">
-                        <div class="icon">{!! svg('package') !!}</div>
-                        <div class="content">
-                            <a href="https://lumen.laravel.com" class="package-title">Lumen</a>
-                            <p>If all you need is an API and lightning fast speed, try Lumen. It’s Laravel super-light.</p>
-                        </div>
-                    </div>
-                    <div class="package last">
                         <div class="icon">{!! svg('package') !!}</div>
                         <div class="content">
                             <a href="https://statamic.com" class="package-title">Statamic</a>


### PR DESCRIPTION
Before this PR the alignment of the packages list on the homepage wasn't good if the text describing the packages wasn't the same length.

![before](https://user-images.githubusercontent.com/27742874/50616858-923b3280-0eea-11e9-87be-b6600a0722b8.png)

It's now fix, the alignment will  stay good no matter the length of the text.

![after](https://user-images.githubusercontent.com/27742874/50616859-923b3280-0eea-11e9-966a-de137e2548f5.png)

