### PR TITLE
Add link to Laravel blog

### DIFF
--- a/resources/views/partials/main-nav.blade.php
+++ b/resources/views/partials/main-nav.blade.php
@@ -30,5 +30,6 @@
 		<li><a href="http://www.laravelpodcast.com/">Podcast</a></li>
 		<li><a href="https://larachat.co">Slack</a></li>
 		<li><a href="https://twitter.com/laravelphp">Twitter</a></li>
+		<li><a href="https://blog.laravel.com">Blog</a></li>
 	</ul>
 </li>

--- a/resources/views/partials/main-nav.blade.php
+++ b/resources/views/partials/main-nav.blade.php
@@ -23,6 +23,7 @@
 
 		<li class="divider"></li>
 
+		<li><a href="https://blog.laravel.com">Blog</a></li>
 		<li><a href="https://laravel.com/certification">Certification</a></li>
 		<li><a href="https://laracasts.com/discuss">Forums</a></li>
 		<li><a href="https://github.com/laravel/laravel">GitHub</a></li>
@@ -30,6 +31,5 @@
 		<li><a href="http://www.laravelpodcast.com/">Podcast</a></li>
 		<li><a href="https://larachat.co">Slack</a></li>
 		<li><a href="https://twitter.com/laravelphp">Twitter</a></li>
-		<li><a href="https://blog.laravel.com">Blog</a></li>
 	</ul>
 </li>


### PR DESCRIPTION
Add blog to Ecosystem links. I saw there were already https://github.com/laravel/laravel.com/pull/209 and https://github.com/laravel/laravel.com/pull/210 but this one just adds link to Ecosystem section - quite useful to know about official blog to anyone who is new in Laravel community and don't follow Twitter 😄 