### PR TITLE
Braintree integration is no longer built-in

### DIFF
--- a/resources/views/marketing.blade.php
+++ b/resources/views/marketing.blade.php
@@ -222,7 +222,7 @@ Route::get('/user/{user}', function(App\User $user)
                         <div class="callout-icon">{!! svg('cashier') !!}</div>
                     </div>
                     <div class="callout-body">
-                        <p>Make subscription billing painless with built-in Stripe and Braintree integrations. Coupons, swapping subscriptions, cancellations, and even PDF invoices are ready out of the box.</p>
+                        <p>Make subscription billing painless with built-in Stripe integration. Coupons, swapping subscriptions, cancellations, and even PDF invoices are ready out of the box.</p>
                     </div>
                 </a>
             </div>


### PR DESCRIPTION
Since v10 of Laravel Cashier, Braintree is no longer built-in so I've removed it from the description of Cashier on the homepage.

However, Braintree does have support, but only from a separate package which maintenance on has been abandoned.