### PR TITLE
link to current larvel.com site repo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## Laravel Website
 
-This is the source of the official Laravel.com website.
+This is the source of the **old** Laravel.com website. For the current version please visit [laravel/laravel.com-next](https://github.com/laravel/laravel.com-next).
 
 The site has two main sections. The front / marketing page which is located at `resources/views/marketing.blade.php` and the documentation pages.
 


### PR DESCRIPTION
this repo is the old laravel.com site.  we will state that so people know to no longer use it, and link them to the new one.

maybe also put the repo in "Read Only" mode as a further indicator people should not be PRing to this repo?