### PR TITLE
Discord Links

### DIFF
--- a/resources/views/marketing.blade.php
+++ b/resources/views/marketing.blade.php
@@ -321,6 +321,7 @@
                 <ul class="list-custom sm:mt-8 grid max-w-md grid-cols-2 gap-4 mt-6 text-sm font-medium leading-4 text-gray-600">
                     <li><a href="https://blog.laravel.com">Blog</a></li>
                     <li><a href="https://laracasts.com">Laracasts</a></li>
+                    <li><a href="https://discord.gg/laravel">Discord</a></li>
                     <!-- <li><a href="http://laravelpodcast.com/">Podcast</a></li> -->
                     <li><a href="https://laravel-news.com">Laravel News</a></li>
                     <li><a href="https://laracon.us/">Laracon</a></li>

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -27,6 +27,7 @@
                 'Jobs' => 'https://larajobs.com',
                 'Certification' => 'https://certification.laravel.com/',
                 'Forums' => 'https://laracasts.com/discuss',
+                'Discord' => 'https://discord.gg/laravel',
             ],
         ],
         [
@@ -174,7 +175,7 @@
                                 </a>
                             </li>
                             <li>
-                                <a href="https://discord.gg/mPZNm7A">
+                                <a href="https://discord.gg/laravel">
                                     <img id="footer__discord" class="w-6 h-6" src="/img/social/discord.min.svg" alt="Discord" width="21" height="24" loading="lazy">
                                     <img id="footer__discord_dark" class="w-6 h-6" src="/img/social/discord.dark.min.svg" alt="Discord" width="21" height="24" loading="lazy">
                                 </a>


### PR DESCRIPTION
Updated the existing discord social media link to the new vanity URL. I also added a more visible discord link under both resources and communities, as discord is already linked in the main documentation, under support:

> https://github.com/laravel/docs/blob/8.x/contributions.md#support-questions