### PR TITLE
Full with search button in docs.blade.php

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -219,7 +219,7 @@
                         <div class="relative mt-8 flex items-center justify-end w-full h-10 lg:mt-0">
                             <div class="flex-1 flex items-center">
                                 <button
-                                    class="relative inline-flex items-center text-gray-800 transition-colors dark:text-gray-400"
+                                    class="relative inline-flex items-center text-gray-800 transition-colors dark:text-gray-400 w-full"
                                     @click.prevent="$dispatch('toggle-search-modal')"
                                 >
                                     <svg class="w-5 h-5 text-gray-700 pointer-events-none transition-colors dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>


### PR DESCRIPTION
When using the documentation, i  wanted to click the search bar but i realised it wasn't long enough and you actually have to click on the search text to get it working

i have extended the width of search bar by add .w-full to the button on line 222 so that you can click on the white space after the search bar and still get the search modal.