### PR TITLE
Updating readme to include instructions on how to setup torchlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ If you want to work on this project on your local machine, you may follow the in
     ```bash
     ./bin/setup.sh
     ```
+   
+### Torchlight Integration
+This project relies on Torchlight for syntax highlighting. You will need to register at [torchlight.dev](https://torchlight.dev/) and generate a free personal token for use in this project. Once generated, add your token to your .env file.
+```yaml
+TORCHLIGHT_TOKEN=
+```
 
 ### Syncing Upstream Changes Into Your Fork 
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ If you want to work on this project on your local machine, you may follow the in
     ```
    
 ### Torchlight Integration
-This project relies on Torchlight for syntax highlighting. You will need to register at [torchlight.dev](https://torchlight.dev/) and generate a free personal token for use in this project. Once generated, add your token to your .env file.
-```yaml
-TORCHLIGHT_TOKEN=
+
+This project relies on Torchlight for syntax highlighting. You will need to create an account at [torchlight.dev](https://torchlight.dev/) and generate a free personal token for use in this project. Once generated, add your token to your .env file:
+
+```ini
+TORCHLIGHT_TOKEN=your-torchlight-token
 ```
 
 ### Syncing Upstream Changes Into Your Fork 


### PR DESCRIPTION
The new laravel.com site requires a Torchlight token to run locally. This PR updates the readme to include a paragraph that points user to the torchlight.dev site to claim a token.