### PR TITLE
Cleaning up routes

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -38,14 +38,6 @@ Route::get('partners', function () {
     return redirect('https://partners.laravel.com');
 });
 
-Route::get('/partner/ideil', function () {
-    return redirect('https://partners.laravel.com/partners/ideil', 301);
-});
-
-Route::get('/partner/curotec', function () {
-    return redirect('https://partners.laravel.com/partners/curotec', 301);
-});
-
 Route::get('partner/{partner}', function ($partner) {
     return redirect('https://partners.laravel.com/partners/'.$partner, 301);
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,9 +34,7 @@ Route::get('docs/6.0/{page?}', function ($page = null) {
 
 Route::get('docs/{version}/{page?}', [DocsController::class, 'show'])->name('docs.version');
 
-Route::get('partners', function () {
-    return redirect('https://partners.laravel.com');
-});
+Route::redirect('partners', 'https://partners.laravel.com');
 
 Route::get('partner/{partner}', function ($partner) {
     return redirect('https://partners.laravel.com/partners/'.$partner, 301);


### PR DESCRIPTION
- Removes two hard coded partner redirects as they follow the general partner redirect format
- Consdenses a redirect block to use `Route::redirect()`