### PR TITLE
Fix modal not closing on same-page results

### DIFF
--- a/resources/views/components/search-modal.blade.php
+++ b/resources/views/components/search-modal.blade.php
@@ -38,6 +38,7 @@
                     aria-label="Search in the documentation"
                     @keydown.arrow-up.prevent="focusPreviousResult()"
                     @keydown.arrow-down.prevent="focusNextResult()"
+                    @click="close()"
                 >
             </div>
 


### PR DESCRIPTION
The issue:

1. Open a documentation page, e.g. https://laravel.com/docs/9.x/releases
2. Search for something that's found on that page, e.g. click `/` and type `Versioning`
3. Select the result and observe that page in the background scrolls to the result, but the overlay remains.

This behaviour is slightly confusing as the UX is different from the other searches and less attentive users might even conclude that "nothing is happening".

I've added a handler that closes the modal on click (it also handles keyboard navigation with Enter). I've tried out multiple scenarios locally and it appears to me that everything works as expected.

There is a slight visual change when the search result leads to another page. Previously the pages swapped with modal visible on the previous page the entire time. Now the modal disappears and than the pages swap. If the previous behaviour (modal visible until the new page arrives) is desired, we can achieve it by this slightly less readable handler:

```js
@click="(new URL(hit.url)).pathname === location.pathname && close()"
```