### PR TITLE
Managing color-scheme and theme-color meta tags based on current theme for better visuals

### DIFF
--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -50,14 +50,14 @@
     @endproduction
 
     @php
-        $forcedLightModeRoutes = collect([
+        $routesThatAreAlwaysLightMode = collect([
             'marketing',
             'team',
         ])
     @endphp
 
     <script>
-        const forcedLightMode = {{ ($forcedLightModeRoutes->contains(request()->route()->getName())) ? 'true' : 'false' }};
+        const alwaysLightMode = {{ ($routesThatAreAlwaysLightMode->contains(request()->route()->getName())) ? 'true' : 'false' }};
     </script>
 
     @include('partials.theme')

--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -49,6 +49,10 @@
         <!-- / Fathom -->
     @endproduction
 
+    <script>
+        const isLandingPage = {{ request()->is('/') ? 'true' : 'false' }};
+    </script>
+
     @include('partials.theme')
 </head>
 <body

--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -38,6 +38,7 @@
     <meta name="msapplication-TileColor" content="#ff2d20">
     <meta name="msapplication-config" content="/img/favicon/browserconfig.xml">
     <meta name="theme-color" content="#ffffff">
+    <meta name="color-scheme" content="light">
 
     <link rel="stylesheet" href="https://use.typekit.net/ins2wgm.css">
     <link rel="stylesheet" type="text/css" href="{{ mix('css/app.css') }}">

--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -49,8 +49,15 @@
         <!-- / Fathom -->
     @endproduction
 
+    @php
+        $forcedLightModeRoutes = collect([
+            'marketing',
+            'team',
+        ])
+    @endphp
+
     <script>
-        const isLandingPage = {{ request()->is('/') ? 'true' : 'false' }};
+        const forcedLightMode = {{ ($forcedLightModeRoutes->contains(request()->route()->getName())) ? 'true' : 'false' }};
     </script>
 
     @include('partials.theme')

--- a/resources/views/partials/theme.blade.php
+++ b/resources/views/partials/theme.blade.php
@@ -18,12 +18,8 @@
             case 'system':
                 if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     document.documentElement.classList.add('dark');
-                    document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'dark')
-                    document.querySelector('meta[name="theme-color"]').setAttribute('content', '#171923')
                 } else {
                     document.documentElement.classList.remove('dark');
-                    document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'light')
-                    document.querySelector('meta[name="theme-color"]').setAttribute('content', '#ffffff')
                 }
                 document.documentElement.setAttribute('color-theme', 'system');
                 break;
@@ -31,16 +27,24 @@
             case 'dark':
                 document.documentElement.classList.add('dark');
                 document.documentElement.setAttribute('color-theme', 'dark');
-                document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'dark')
-                document.querySelector('meta[name="theme-color"]').setAttribute('content', '#171923')
                 break;
 
             case 'light':
                 document.documentElement.classList.remove('dark');
                 document.documentElement.setAttribute('color-theme', 'light');
-                document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'light')
-                document.querySelector('meta[name="theme-color"]').setAttribute('content', '#ffffff')
                 break;
+        }
+
+        if(!isLandingPage) {
+            if(document.documentElement.classList.contains('dark')) {
+                document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'dark');
+                document.querySelector('meta[name="theme-color"]').setAttribute('content', '#171923');
+
+                return;
+            }
+
+            document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'light');
+            document.querySelector('meta[name="theme-color"]').setAttribute('content', '#ffffff');
         }
     }
 

--- a/resources/views/partials/theme.blade.php
+++ b/resources/views/partials/theme.blade.php
@@ -18,8 +18,12 @@
             case 'system':
                 if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
                     document.documentElement.classList.add('dark');
+                    document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'dark')
+                    document.querySelector('meta[name="theme-color"]').setAttribute('content', '#171923')
                 } else {
                     document.documentElement.classList.remove('dark');
+                    document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'light')
+                    document.querySelector('meta[name="theme-color"]').setAttribute('content', '#ffffff')
                 }
                 document.documentElement.setAttribute('color-theme', 'system');
                 break;
@@ -27,11 +31,15 @@
             case 'dark':
                 document.documentElement.classList.add('dark');
                 document.documentElement.setAttribute('color-theme', 'dark');
+                document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'dark')
+                document.querySelector('meta[name="theme-color"]').setAttribute('content', '#171923')
                 break;
 
             case 'light':
                 document.documentElement.classList.remove('dark');
                 document.documentElement.setAttribute('color-theme', 'light');
+                document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'light')
+                document.querySelector('meta[name="theme-color"]').setAttribute('content', '#ffffff')
                 break;
         }
     }

--- a/resources/views/partials/theme.blade.php
+++ b/resources/views/partials/theme.blade.php
@@ -36,7 +36,7 @@
         }
 
         if(! alwaysLightMode) {
-            if(document.documentElement.classList.contains('dark')) {
+            if (document.documentElement.classList.contains('dark')) {
                 document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'dark');
                 document.querySelector('meta[name="theme-color"]').setAttribute('content', '#171923');
 

--- a/resources/views/partials/theme.blade.php
+++ b/resources/views/partials/theme.blade.php
@@ -35,7 +35,7 @@
                 break;
         }
 
-        if(!isLandingPage) {
+        if(!forcedLightMode) {
             if(document.documentElement.classList.contains('dark')) {
                 document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'dark');
                 document.querySelector('meta[name="theme-color"]').setAttribute('content', '#171923');

--- a/resources/views/partials/theme.blade.php
+++ b/resources/views/partials/theme.blade.php
@@ -35,7 +35,7 @@
                 break;
         }
 
-        if(!forcedLightMode) {
+        if(! alwaysLightMode) {
             if(document.documentElement.classList.contains('dark')) {
                 document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'dark');
                 document.querySelector('meta[name="theme-color"]').setAttribute('content', '#171923');

--- a/routes/web.php
+++ b/routes/web.php
@@ -79,7 +79,7 @@ Route::get('/', function () {
             ],
         ])->shuffle(),
     ]);
-});
+})->name('marketing');
 
 Route::get('team', function () {
     return view('team', [
@@ -132,4 +132,4 @@ Route::get('team', function () {
             ],
         ]
     ]);
-});
+})->name('team');


### PR DESCRIPTION
Hi! I noticed the Laravel website was not taking the current theme into account to show matching scrollbars and browser UI (where supported), so i went ahead and improved it.

This is what im talking about: 
<div align="center">
<img src="https://user-images.githubusercontent.com/45177590/182641225-02fc65fc-a60e-4ffe-aba2-495c453a84f7.png" alt="Example with wrong colors" width="300" />
</div>

![2a](https://user-images.githubusercontent.com/45177590/182641364-8f7be18e-5abc-4770-9c9b-43a63d7b5af3.png)

As you can see, the top of the Safari app, and the scrollbar on Windows is not matching the site current theme, which in the photos is "dark". 

I added the necessary meta tags to make all of this react to the current theme, i also took care and made it so this changes dont affect the landing ('/') and team ('/team') page as this page's design is not ready for dark mode. Basically this pages now have a "forced" light mode. No changes there.

Here is how it looks:

Dark mode:

<div align="center">
<img src="https://user-images.githubusercontent.com/45177590/182643073-04789396-a69f-4bea-8ea0-a558c6251989.png" alt="Example with correct colors" width="300" />
</div>

![2b](https://user-images.githubusercontent.com/45177590/182643195-13a8dc27-bc90-4d08-8a3c-70509425c921.png)

Light mode:

<div align="center">
<img src="https://user-images.githubusercontent.com/45177590/182643306-b70cc8e9-7811-4673-8f65-9ce78847c13a.png" alt="Example with correct colors" width="300" />
</div>

![2c](https://user-images.githubusercontent.com/45177590/182643393-e5fecfd3-f2a4-4eb7-bee7-8295a309b2a6.png)

I've tested it and it all seems to work nicely.

Thank you!
