### PR TITLE
Fixed a bug where the color-scheme and theme-color meta tags arent updating when on 'system' theme and the user changes his OS theme manually

### DIFF
--- a/resources/views/partials/theme.blade.php
+++ b/resources/views/partials/theme.blade.php
@@ -41,7 +41,7 @@
     }
 
     function updateThemeAndSchemeColor() {
-        if(! alwaysLightMode) {
+        if (! alwaysLightMode) {
             if (document.documentElement.classList.contains('dark')) {
                 document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'dark');
                 document.querySelector('meta[name="theme-color"]').setAttribute('content', '#171923');

--- a/resources/views/partials/theme.blade.php
+++ b/resources/views/partials/theme.blade.php
@@ -7,6 +7,8 @@
                 document.documentElement.classList.remove('dark');
             }
         }
+
+        updateThemeAndSchemeColor();
     });
 
     function updateTheme() {
@@ -35,6 +37,10 @@
                 break;
         }
 
+        updateThemeAndSchemeColor();
+    }
+
+    function updateThemeAndSchemeColor() {
         if(! alwaysLightMode) {
             if (document.documentElement.classList.contains('dark')) {
                 document.querySelector('meta[name="color-scheme"]').setAttribute('content', 'dark');


### PR DESCRIPTION
This is a fix for a bug i introduced in the last pull request 😑

If you select the 'system' theme and then you manually change your OS theme to light mode or viceversa, you will see this:

![err](https://user-images.githubusercontent.com/45177590/182882883-ddad3beb-043b-4dee-b066-23acdf583f4f.png)

I forgot to update the meta tags when the user manually changes his OS theme and has the 'system' theme selected, using the JS event we were already using

This PR fixes it :)