### PR TITLE
add support for ctrl + k to open search in docs

### DIFF
--- a/resources/js/components/search.js
+++ b/resources/js/components/search.js
@@ -57,7 +57,12 @@ export default function () {
             }
         },
         handleKeydown(event) {
-            if (event.key === '/' || (event.key === 'p' && event.metaKey) || (event.key === 'k' && event.metaKey)) {
+            if (
+                event.key === "/" ||
+                (event.key === "p" && event.metaKey) ||
+                (event.key === "k" && event.metaKey) ||
+                (event.key === "k" && event.ctrlKey)
+            ) {
                 event.preventDefault();
                 this.open = true;
                 this.$refs.searchInput.focus();


### PR DESCRIPTION
Following the same shortcut key for opening the search option. 
https://vitejs.dev/
https://tailwindcss.com/