### PR TITLE
revert #240; breaks searching on mobile.

### DIFF
--- a/resources/views/components/search-modal.blade.php
+++ b/resources/views/components/search-modal.blade.php
@@ -50,7 +50,6 @@
                     aria-label="Search in the documentation"
                     @keydown.arrow-up.prevent="focusPreviousResult()"
                     @keydown.arrow-down.prevent="focusNextResult()"
-                    @click="close()"
                 >
             </div>
 


### PR DESCRIPTION
This PR reverts #240 as it has broken the search on mobile and, to some extent, on desktop as well.

The event listener was applied to the search input meaning that any click on the text input will close the modal.


https://user-images.githubusercontent.com/24803032/184752545-a9202afd-3772-4768-a3e9-cfe348417fdc.MP4

I'm guessing this event listener was intended to be applied to the items in the result list instead of the text input, but I can't test it locally so I am just gonna revert this and we can follow up with another PR for the original improvement with feedback from @tontonsb.