### PR TITLE
Sends users to same page when they click upgrade notice on previous version docs.

### DIFF
--- a/app/Http/Controllers/DocsController.php
+++ b/app/Http/Controllers/DocsController.php
@@ -123,6 +123,7 @@ class DocsController extends Controller
             'versions' => Documentation::getDocVersions(),
             'currentSection' => $section,
             'canonical' => $canonical,
+            'sectionPage' => $page ? $sectionPage : '',
         ]);
     }
 

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -241,7 +241,7 @@
 
                                         <p class="mb-0 lg:ml-4">
                                             <strong>WARNING</strong> You're browsing the documentation for an old version of Laravel.
-                                            Consider upgrading your project to <a href="{{ route('docs.version', DEFAULT_VERSION) }}">Laravel {{ DEFAULT_VERSION }}</a>.
+                                            Consider upgrading your project to <a href="{{ route('docs.version', [DEFAULT_VERSION, $sectionPage]) }}">Laravel {{ DEFAULT_VERSION }}</a>.
                                         </p>
                                     </div>
                                 </blockquote>


### PR DESCRIPTION
There are many a times when i google search something about Laravel  or even when I get answer  (on SO, GitHub or Laracast) and the documentation reference link I get sends me to an old version page.

But when i click on the upgrade notice link, it sends me to the root of the latest version instead of the actual page. But I can find what I need quicker, if it should send me to the same page of the current version.

If previous version page is not available in the latest version, it should throw 404 and I will at least know that it is no longer supported.

This will not help only me but I have a feeling lots of people will also like it.