### PR TITLE
fix flash of 'no results' when searching

### DIFF
--- a/resources/js/components/search.js
+++ b/resources/js/components/search.js
@@ -5,6 +5,7 @@ export default function () {
         search: '',
         open: false,
         hits: [],
+        searching: false,
         init() {
             const searchClient = algoliasearch(algolia_app_id, algolia_search_key);
 
@@ -12,8 +13,12 @@ export default function () {
 
             this.$watch('search', (query) => {
                 if (!query) {
-                    return this.hits = [];
+                    this.searching = false
+                    this.hits = [];
+                    return
                 }
+
+                this.searching = true
 
                 index.search(query, {
                     hitsPerPage: 5,
@@ -21,6 +26,7 @@ export default function () {
                     highlightPreTag: '<em class="not-italic bg-red-600 bg-opacity-25">',
                     highlightPostTag: '</em>'
                 }).then(({ hits }) => {
+                    this.searching = false
                     this.hits = hits;
                 });
             });

--- a/resources/views/components/search-modal.blade.php
+++ b/resources/views/components/search-modal.blade.php
@@ -92,7 +92,11 @@
                     </template>
                 </div>
 
-                <div x-show="! hits.length" x-cloak class="mt-8 pb-32">
+                <div x-show="! hits.length && searching" x-cloak class="mt-8 pb-32">
+                    Searching...
+                </div>
+
+                <div x-show="! hits.length && ! searching" x-cloak class="mt-8 pb-32">
                     <div x-text="`We didn't find any result for '${search}'. Sorry!`"></div>
                 </div>
             </div>


### PR DESCRIPTION
On the current website, for any fresh search I always see a flash of:

> "We didn't find any result for 'MY_QUERY_HERE'. Sorry!"

in the result box while the results are loading and then the results for the query are shown.

This adds a new state to show "Searching..." when there are no results but a query is still in flight.

Here is a video showing the problem:


https://user-images.githubusercontent.com/24803032/190534854-ca1bdae3-1719-4b1d-a036-af92b74e0dc4.mov


I don't have a valid Algolia key, so I haven't been able to 100% confirm this fix.