### PR TITLE
Remove unused Parsedown

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
     "license": "MIT",
     "require": {
         "php": "^7.3|^8.0",
-        "erusev/parsedown-extra": "^0.8.1",
         "fideloper/proxy": "^4.2",
         "laravel/framework": "^8.0",
         "laravel/tinker": "^2.2",


### PR DESCRIPTION
Parsedown is no longer being used since https://github.com/laravel/laravel.com/pull/205 and can therefor be removed.

It was previously used in `app/Documentation.php`

You will still need to run `composer update`

(In the following days I will create follow up PRs to upgrade to Laravel 9, PHP 8.1 and Vite if that is wanted)