### PR TITLE
Widen content area

### DIFF
--- a/resources/css/_typography.css
+++ b/resources/css/_typography.css
@@ -197,6 +197,10 @@
     }
 }
 
+.max-w-prose {
+    max-width: 90ch !important;
+}
+
 .list-custom li {
     position: relative;
     padding-left: 1rem;


### PR DESCRIPTION
The `.max-w-prose { max-width: 65ch !important; }` class is currently used for the main content block of the docs. In my opinion this width is way too small and can be increased (and since this is documentation and I assume that developers often browse through these pages I think this is warranted). I increased it to roughly the same width of viewing a `README.md` file on Github to `max-width: 90ch !important`.

This change has no effect on mobile viewports since it is a `max-width` property and thus only activates at bigger screens.

Also note that the content is currently not centered (even though it would seem like it is on 1920x1080) but the new width might change this perception depending on your resolution.

See below for screenshots from a 1920x1080 screen.

Before:
![before](https://user-images.githubusercontent.com/10498595/210463226-388ae35e-4de5-4f03-9327-80ed5a42c5dc.png)

After:
![after](https://user-images.githubusercontent.com/10498595/210463252-7cd1dad3-4c1f-4662-8ffe-357365d96475.png)
