### PR TITLE
Add Laravel Docs 10.x

### DIFF
--- a/app/Documentation.php
+++ b/app/Documentation.php
@@ -168,6 +168,7 @@ class Documentation
     {
         return [
             'master' => 'Master',
+            '10.x' => '10.x',
             '9.x' => '9.x',
             '8.x' => '8.x',
             '7.x' => '7.x',

--- a/bin/checkout_latest_docs.sh
+++ b/bin/checkout_latest_docs.sh
@@ -2,6 +2,7 @@
 
 DOCS_VERSIONS=(
   master
+  10.x
   9.x
   8.x
   7.x

--- a/build/docs.sh
+++ b/build/docs.sh
@@ -9,6 +9,7 @@ cd ${docs}/6.x && git pull origin 6.x
 cd ${docs}/7.x && git pull origin 7.x
 cd ${docs}/8.x && git pull origin 8.x
 cd ${docs}/9.x && git pull origin 9.x
+cd ${docs}/10.x && git pull origin 10.x
 cd ${docs}/master && git pull origin master
 
 cd $base && php artisan docs:clear-cache

--- a/build/doctum/doctum.php
+++ b/build/doctum/doctum.php
@@ -20,6 +20,7 @@ $versions = GitVersionCollection::create($dir)
 	->add('7.x', 'Laravel 7.x')
 	->add('8.x', 'Laravel 8.x')
 	->add('9.x', 'Laravel 9.x')
+	->add('10.x', 'Laravel 10.x')
 	->add('master', 'Laravel Dev');
 
 return new Doctum($iterator, [


### PR DESCRIPTION
Preparing laravel.com for the Laravel 10 Release. The default branch is still 9.x which need to be changed after the release of Laravel 10.

Before merging you should create a new branch `10.x` in https://github.com/laravel/docs