### PR TITLE
Support policy highlight style doesn't apply

### DIFF
--- a/resources/js/docs.js
+++ b/resources/js/docs.js
@@ -120,7 +120,7 @@ function replaceBlockquote(el, regex, getImageAndColorByType) {
 }
 
 function highlightSupportPolicyTable() {
-    const table = document.querySelector('.docs_main #support-policy ~ table:first-of-type');
+    const table = document.querySelector('.docs_main #support-policy ~ div table:first-of-type');
 
     if (table) {
         const currentDate = new Date().valueOf();


### PR DESCRIPTION
Fix a regression that causes the support policy highlight style to no longer apply.
This happened because the table is now wrapped in a div.