### PR TITLE
Add direct link to most recent version of page

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -198,6 +198,8 @@
                                         <p class="mb-0 lg:ml-4">
                                             <strong>WARNING</strong> You're browsing the documentation for an old version of Laravel.
                                             Consider upgrading your project to <a href="{{ route('docs.version', DEFAULT_VERSION) }}">Laravel {{ DEFAULT_VERSION }}</a>.
+                                            <a href="{{ preg_replace('/https:\/\/laravel.com\/docs\/([^\/]*)\/(.*)$/', route('docs.version', DEFAULT_VERSION) . '/$2', url()->full()) }}">
+                                            Latest version of this page</a> (may not exist).
                                         </p>
                                     </div>
                                 </blockquote>


### PR DESCRIPTION
I suspect this will improve SEO as well. Google now often comes up with random old versions of the Laravel documentation.

Since there is sometimes documentation name reshuffling, I would recommend to improve the 'Page not found' search behaviour as well. E.g. a simple link/button to enter the current page name into search. Or auto populate there search query with that.