### PR TITLE
Add dark mode css to Algolia modal

### DIFF
--- a/resources/css/_dark_mode.css
+++ b/resources/css/_dark_mode.css
@@ -42,6 +42,20 @@
     }
 }
 
+/* Algolia modal */
+.DocSearch-Modal {
+    @apply dark:bg-dark-800;
+    @apply dark:text-gray-400;
+
+    & .DocSearch-Footer, & .DocSearch-Form {
+        @apply dark:bg-dark-600;
+    }
+
+    & .DocSearch-Input {
+        @apply dark:text-gray-200;
+    }
+}
+
 /* Pound sign before headings */
 .dark .docs_main {
     & h4 a:before, & h3 a:before, & h2 a:before {


### PR DESCRIPTION
as mentioned in this [discussion](https://github.com/laravel/framework/discussions/46425), Algolia modal does not comply with dark mode.  as mentioned in this [post](https://discourse.algolia.com/t/dynamic-dark-mode-support-a-la-media-prefers-color-scheme-dark/15004) Algolia leaves it to the developer to implement dark mode. this pr will fix that.