### PR TITLE
Send the user to the latest version of the same page in the upgrade prompt.

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -191,7 +191,7 @@
 
                                         <p class="mb-0 lg:ml-4">
                                             <strong>WARNING</strong> You're browsing the documentation for an old version of Laravel.
-                                            Consider upgrading your project to <a href="{{ route('docs.version', DEFAULT_VERSION) }}">Laravel {{ DEFAULT_VERSION }}</a>.
+                                            Consider upgrading your project to <a href="{{ route('docs.version', ['version' => DEFAULT_VERSION, 'page' => request()->route()->parameter('page')]) }}">Laravel {{ DEFAULT_VERSION }}</a>.
                                         </p>
                                     </div>
                                 </blockquote>


### PR DESCRIPTION
This has previously been submitted in #272, #254, #123.

Taylor noted in https://github.com/laravel/laravel.com/pull/254#issuecomment-1221368435 that not all versions have all pages, which is true. But in Laravel 10 and 9 there were only additions, and in versions 7 and 8 only one page was removed respectively.

Submitting again in case the viewpoint has changed in 2023 😀