### PR TITLE
Add Cashier redirects

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -26,6 +26,14 @@ if (! defined('SHOW_PROMO')) {
 
 Route::get('docs', [DocsController::class, 'showRootPage']);
 
+Route::get('docs/cashier', function () {
+    return redirect(trim('/docs/'.DEFAULT_VERSION.'/billing/'), 301);
+});
+
+Route::get('docs/{version}/cashier', function ($version) {
+    return redirect(trim('/docs/'.$version.'/billing/'), 301);
+});
+
 Route::get('docs/6.0/{page?}', function ($page = null) {
     $page = $page ?: 'installation';
     $page = $page == DEFAULT_VERSION ? 'installation' : $page;


### PR DESCRIPTION
I constantly get bit by a 404 each time I try and visit https://laravel.com/docs/cashier

This PR adds redirects to redirect `/docs/cashier` to `/docs/billing`, and `/docs/{version}/cashier` to `/docs/{version}/billing`