### PR TITLE
Update documentation page title to display dynamic Laravel version

### DIFF
--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -3,7 +3,13 @@
 
 <head>
     <meta charset="utf-8">
-    <title>{{ isset($title) ? $title . ' - ' : null }}Laravel - The PHP Framework For Web Artisans</title>
+
+    @if (isset($currentVersion) && $currentVersion == 'master')
+    <title>{{ isset($title) ? $title . ' - ' : null }}Laravel Upcoming - The PHP Framework For Web Artisans</title>
+    @else
+    <title>{{ isset($title) ? $title . ' - ' : null }}Laravel {{ isset($currentVersion) ? $currentVersion . ' ' : null }}- The PHP Framework For Web Artisans</title>
+    @endif
+
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 
     @if (isset($canonical))


### PR DESCRIPTION
I've made some improvements to the title tag on the documentation pages, so now it dynamically displays the Laravel version.

These changes improve how the docs links are displayed in search engines and in browsers.

I've added a check to see if the $currentVersion variable is set, and it's currently being set only by the DocsController.

When $currentVersion is master, it adds "Upcoming" to title:

> Installation - Laravel Upcoming - The PHP Framework For Web Artisans

And when $currentVersion is set to a specific version, it adds that version to the title:

> Installation - Laravel 10.x - The PHP Framework For Web Artisans