### PR TITLE
Fix Laravel version warning callout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravel-website",
+    "name": "laravel.com",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -184,15 +184,17 @@
                         <section class="docs_main max-w-prose">
                             @unless ($currentVersion == 'master' || version_compare($currentVersion, DEFAULT_VERSION) >= 0)
                                 <blockquote>
-                                    <div class="mb-10 max-w-2xl mx-auto px-4 py-8 shadow-lg dark:bg-dark-600 lg:flex lg:items-center">
-                                        <div class="w-20 h-20 mb-6 flex items-center justify-center shrink-0 bg-orange-600 lg:mb-0">
-                                            <img src="{{ asset('/img/callouts/exclamation.min.svg') }}" alt="Icon" class="opacity-75" />
-                                        </div>
+                                    <div class="callout">
+                                        <div class="mb-10 max-w-2xl mx-auto px-4 py-8 shadow-lg dark:bg-dark-600 lg:flex lg:items-center">
+                                            <div class="w-20 h-20 mb-6 flex items-center justify-center shrink-0 bg-orange-600 lg:mb-0">
+                                                <img src="{{ asset('/img/callouts/exclamation.min.svg') }}" alt="Icon" class="opacity-75" />
+                                            </div>
 
-                                        <p class="mb-0 lg:ml-4">
-                                            <strong>WARNING</strong> You're browsing the documentation for an old version of Laravel.
-                                            Consider upgrading your project to <a href="{{ route('docs.version', DEFAULT_VERSION) }}">Laravel {{ DEFAULT_VERSION }}</a>.
-                                        </p>
+                                            <p class="mb-0 lg:ml-4">
+                                                <strong>WARNING</strong> You're browsing the documentation for an old version of Laravel.
+                                                Consider upgrading your project to <a href="{{ route('docs.version', DEFAULT_VERSION) }}">Laravel {{ DEFAULT_VERSION }}</a>.
+                                            </p>
+                                        </div>
                                     </div>
                                 </blockquote>
                             @endunless


### PR DESCRIPTION
The Laravel version warning callout is missing a wrapper resulting in additional margin after the paragraph.

By adding a wrapper with the "callout" class this issue can be resolved.

![image](https://github.com/laravel/laravel.com/assets/140138716/6cf441ba-d553-4ef0-9a3d-0faf640dc677)
