### PR TITLE
Use the Discord vanity URL in footer link

### DIFF
--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -98,7 +98,7 @@
                         </a>
                     </li>
                     <li>
-                        <a href="https://discord.gg/mPZNm7A">
+                        <a href="https://discord.gg/laravel">
                             <img class="{{ $is_docs_page ? 'hidden dark:inline-block' : 'hidden' }} w-6 h-6"
                                 src="/img/social/discord.dark.min.svg" alt="Discord" width="21" height="24"
                                 loading="lazy">


### PR DESCRIPTION
Since there's a neat https://discord.gg/laravel link available (which is also used in the contribution guide), I think it's beneficial to use the vanity link in the footer as well. This makes it easier to remember the invite link as well.