### PR TITLE
Made docs side nav sticky on large screen.

### DIFF
--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -8,7 +8,7 @@
     <div class="relative overflow-auto dark:bg-dark-700" id="docsScreen">
         <div class="relative lg:flex lg:items-start">
             <aside class="hidden fixed top-0 bottom-0 left-0 z-20 h-full w-16 bg-gradient-to-b from-gray-100 to-white transition-all duration-300 overflow-hidden lg:sticky lg:w-80 lg:shrink-0 lg:flex lg:flex-col lg:justify-end lg:items-end 2xl:max-w-lg 2xl:w-full dark:from-dark-800 dark:to-dark-700">
-                <div class="relative min-h-0 flex-1 flex flex-col xl:w-80">
+                <div class="relative lg:fixed lg:top-4 lg:h-full lg:pb-12 min-h-0 flex-1 flex flex-col xl:w-80">
                     <a href="/" class="flex items-center py-8 px-4 lg:px-8 xl:px-16">
                         <img
                             class="w-8 h-8 shrink-0 transition-all duration-300 lg:w-12 lg:h-12"
@@ -25,7 +25,7 @@
                             height="29"
                         >
                     </a>
-                    <div class="overflow-y-auto overflow-x-hidden px-4 lg:overflow-hidden lg:px-8 xl:px-16">
+                    <div class="overflow-y-auto overflow-x-hidden px-4 lg:px-8 xl:px-16">
                         <nav id="indexed-nav" class="hidden lg:block lg:mt-4">
                             <div class="docs_sidebar">
                                 {!! $index !!}


### PR DESCRIPTION
Made docs side nav sticky on large screen, with overflow scrolling when the menu gets too long.
Current experience of having to scroll all the way up to find a different link is not very nice.