### PR TITLE
Remove unneeded method usage in Documentation.php

### DIFF
--- a/app/Documentation.php
+++ b/app/Documentation.php
@@ -96,7 +96,7 @@ class Documentation
             }
 
             return [
-                'pages' => collect(explode(PHP_EOL, $this->replaceLinks($version, $this->files->get($path))))
+                'pages' => collect(explode(PHP_EOL, $this->files->get($path)))
                     ->filter(fn ($line) => Str::contains($line, '/docs/{{version}}/'))
                     ->map(fn ($line) => resource_path(Str::of($line)->afterLast('(/')->before(')')->replace('{{version}}', $version)->append('.md')))
                     ->filter(fn ($path) => $this->files->exists($path))


### PR DESCRIPTION
I believe the `replaceLinks()` method usage is doing nothing.
Since there is no `%7B%7Bversion%7D%7D` string in the `documentation.md` file this method just returns the file content as it is. And afterwards `replace('{{version}}', $version)` include the version to the links.