### PR TITLE
Update meta titles to match the current page title

### DIFF
--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -17,20 +17,32 @@
     @endif
 
     <!-- Primary Meta Tags -->
-    <meta name="title" content="Laravel - The PHP Framework For Web Artisans">
+    @if (isset($currentVersion) && $currentVersion == 'master')
+    <meta name="title" content="{{ isset($title) ? $title . ' - ' : null }}Laravel Upcoming - The PHP Framework For Web Artisans">
+    @else
+    <meta name="title" content="{{ isset($title) ? $title . ' - ' : null }}Laravel {{ isset($currentVersion) ? $currentVersion . ' ' : null }}- The PHP Framework For Web Artisans">
+    @endif
     <meta name="description" content="Laravel is a PHP web application framework with expressive, elegant syntax. We’ve already laid the foundation — freeing you to create without sweating the small things.">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://laravel.com/">
-    <meta property="og:title" content="Laravel - The PHP Framework For Web Artisans">
+    @if (isset($currentVersion) && $currentVersion == 'master')
+    <meta name="og:title" content="{{ isset($title) ? $title . ' - ' : null }}Laravel Upcoming - The PHP Framework For Web Artisans">
+    @else
+    <meta name="og:title" content="{{ isset($title) ? $title . ' - ' : null }}Laravel {{ isset($currentVersion) ? $currentVersion . ' ' : null }}- The PHP Framework For Web Artisans">
+    @endif    
     <meta property="og:description" content="Laravel is a PHP web application framework with expressive, elegant syntax. We’ve already laid the foundation — freeing you to create without sweating the small things.">
     <meta property="og:image" content="https://laravel.com/img/og-image.jpg">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://laravel.com/">
-    <meta property="twitter:title" content="Laravel - The PHP Framework For Web Artisans">
+    @if (isset($currentVersion) && $currentVersion == 'master')
+    <meta name="twitter:title" content="{{ isset($title) ? $title . ' - ' : null }}Laravel Upcoming - The PHP Framework For Web Artisans">
+    @else
+    <meta name="twitter:title" content="{{ isset($title) ? $title . ' - ' : null }}Laravel {{ isset($currentVersion) ? $currentVersion . ' ' : null }}- The PHP Framework For Web Artisans">
+    @endif
     <meta property="twitter:description" content="Laravel is a PHP web application framework with expressive, elegant syntax. We’ve already laid the foundation — freeing you to create without sweating the small things.">
     <meta property="twitter:image" content="https://laravel.com/img/og-image.jpg">
 


### PR DESCRIPTION
### This PR
- [x] Sets `meta:title` to match the current page title 
- [x] Sets `meta:og:title` to match current page title
- [x] Sets `meta:twiiter:title` to match current page title

This PR is basically a KISS version of #263 PR to just improve sharing across platforms when sharing docs. 