### PR TITLE
Update checkout_latest_docs.sh to add 11.x

### DIFF
--- a/bin/checkout_latest_docs.sh
+++ b/bin/checkout_latest_docs.sh
@@ -2,6 +2,7 @@
 
 DOCS_VERSIONS=(
   master
+  11.x
   10.x
   9.x
   8.x


### PR DESCRIPTION
This quick PR adds the missing 11.x version tag to the `DOCS_VERSIONS` array in the `checkout_latest_docs.sh` script. 