### PR TITLE
Restore per-load randomness

### DIFF
--- a/resources/views/components/header-news-bar.blade.php
+++ b/resources/views/components/header-news-bar.blade.php
@@ -1,9 +1,9 @@
-<?php
-    $news = Illuminate\Support\Arr::random(['nova', 'forge', 'vapor', 'herd', 'pulse', 'reverb', 'laracon', 'laracon-au']);
-?>
+@php
+    $news = ['nova', 'forge', 'vapor', 'herd', 'pulse', 'reverb', 'laracon', 'laracon-au'];
+@endphp
 
-<div class="hidden lg:flex items-center justify-center bg-gradient-to-b from-red-500 to-red-600 p-2 text-center text-white text-sm">
-    @if ($news === 'herd')
+<div class="hidden lg:flex items-center justify-center bg-gradient-to-b from-red-500 to-red-600 p-2 text-center text-white text-sm h-9">
+    <template id="news-herd">
         <div>
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-white" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" stroke-linecap="round" fill="none" stroke-linejoin="round">
               <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
@@ -18,57 +18,65 @@
         <div class="mt-px ml-1">
             Get started with PHP and Laravel faster than ever using <a href="https://herd.laravel.com" class="underline">Laravel Herd</a>.
         </div>
+    </template>
 
-    @elseif ($news === 'laracon')
+    <template id="news-laracon">
         <div><svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg></div>
 
         <div class="mt-px ml-1">
             Join us in Dallax, TX! Tickets are now available for <a href="https://laracon.us" class="underline">Laracon US</a>.
         </div>
+    </template>
 
-    @elseif ($news === 'laracon-in')
+    <template id="news-laracon-in">
         <div><svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg></div>
 
         <div class="mt-px ml-1">
             Let's go to India! Tickets are now available for <a href="https://laracon.in" class="underline">Laracon IN</a>.
         </div>
+    </template>
 
-    @elseif ($news === 'laracon-eu')
+    <template id="news-laracon-eu">
         <div><svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg></div>
 
         <div class="mt-px ml-1">
             Let's go to Europe! Tickets are now available for <a href="https://laracon.eu" class="underline">Laracon EU</a>.
         </div>
+    </template>
 
-    @elseif ($news === 'laracon-au')
+    <template id="news-laracon-au">
         <div><svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3.055 11H5a2 2 0 012 2v1a2 2 0 002 2 2 2 0 012 2v2.945M8 3.935V5.5A2.5 2.5 0 0010.5 8h.5a2 2 0 012 2 2 2 0 104 0 2 2 0 012-2h1.064M15 20.488V18a2 2 0 012-2h3.064M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg></div>
 
         <div class="mt-px ml-1">
             Let's go down under! Tickets are now available for <a href="https://laracon.au" class="underline">Laracon AU</a>.
         </div>
+    </template>
 
-    @elseif ($news === 'forge')
+    <template id="news-forge">
         <div><svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path></svg></div>
 
         <div class="mt-px ml-1">
             Servers with PHP 8.3 are now available for provisioning via <a href="https://forge.laravel.com" class="underline">Laravel Forge</a>.
         </div>
+    </template>
 
-    @elseif ($news === 'vapor')
+    <template id="news-vapor">
         <div><svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z"></path></svg></div>
 
         <div class="mt-px ml-1">
             Deploy Laravel with the infinite scale of serverless using <a href="https://vapor.laravel.com" class="underline">Laravel Vapor</a>.
         </div>
+    </template>
 
-    @elseif ($news === 'pulse')
+    <template id="news-pulse">
         <div><svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 15a4 4 0 004 4h9a5 5 0 10-.1-9.999 5.002 5.002 0 10-9.78 2.096A4.001 4.001 0 003 15z"></path></svg></div>
 
         <div class="mt-px ml-1">
             How's your health? Check your application's vital signs using <a href="https://pulse.laravel.com" class="underline">Laravel Pulse</a>.
         </div>
+    </template>
 
-    @elseif ($news === 'reverb')
+    <template id="news-reverb">
         <div>
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-white" width="44" height="44" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
               <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
@@ -84,8 +92,9 @@
         <div class="mt-px ml-1">
             Incoming transmission received. <a href="https://reverb.laravel.com" class="underline">Laravel Reverb</a> is now available!
         </div>
+    </template>
 
-    @elseif ($news === 'nova')
+    <template id="news-nova">
         <div>
             <svg class="w-5 h-5 text-white" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 01-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 006.16-12.12A14.98 14.98 0 009.631 8.41m5.96 5.96a14.926 14.926 0 01-5.841 2.58m-.119-8.54a6 6 0 00-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 00-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 01-2.448-2.448 14.9 14.9 0 01.06-.312m-2.24 2.39a4.493 4.493 0 00-1.757 4.306 4.493 4.493 0 004.306-1.758M16.5 9a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z"></path>
@@ -95,8 +104,9 @@
         <div class="mt-px ml-1">
             Take your administration backend to another dimension with <a href="https://nova.laravel.com" class="underline">Laravel Nova</a>.
         </div>
+    </template>
 
-    @elseif ($news === 'careers')
+    <template id="news-careers">
         <div>
             <svg class="w-5 h-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-6 h-6">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M20.25 14.15v4.25c0 1.094-.787 2.036-1.872 2.18-2.087.277-4.216.42-6.378.42s-4.291-.143-6.378-.42c-1.085-.144-1.872-1.086-1.872-2.18v-4.25m16.5 0a2.18 2.18 0 0 0 .75-1.661V8.706c0-1.081-.768-2.015-1.837-2.175a48.114 48.114 0 0 0-3.413-.387m4.5 8.006c-.194.165-.42.295-.673.38A23.978 23.978 0 0 1 12 15.75c-2.648 0-5.195-.429-7.577-1.22a2.016 2.016 0 0 1-.673-.38m0 0A2.18 2.18 0 0 1 3 12.489V8.706c0-1.081.768-2.015 1.837-2.175a48.111 48.111 0 0 1 3.413-.387m7.5 0V5.25A2.25 2.25 0 0 0 13.5 3h-3a2.25 2.25 0 0 0-2.25 2.25v.894m7.5 0a48.667 48.667 0 0 0-7.5 0M12 12.75h.008v.008H12v-.008Z" />
@@ -107,5 +117,12 @@
             Laravel is hiring! <a href="{{ route('careers') }}" class="underline">Help us build the future of Laravel</a>.
         </div>
 
-    @endif
+    </template>
 </div>
+<script>
+    const activeNewsTemplate = document.getElementById(
+        'news-'+@js($news)[Math.floor(Math.random() * {{ count($news) }})]
+    )
+
+    activeNewsTemplate.replaceWith(activeNewsTemplate.content)
+</script>

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -33,60 +33,45 @@
                         </nav>
 
                         @php
-                            $promote = null;
-
-                            switch(random_int(1, 5)) {
-                                case 1:
-                                    $promote = 'forge';
-                                    break;
-
-                                case 2:
-                                    $promote = 'vapor';
-                                    break;
-
-                                case 3:
-                                    $promote = 'nova';
-                                    break;
-
-                                case 4:
-                                    $promote = 'pulse';
-                                    break;
-
-                                case 5:
-                                    $promote = 'reverb';
-                                    break;
-                            }
+                            $promotions = ['forge', 'vapor', 'nova', 'pulse', 'reverb'];
                         @endphp
 
-                        @if ($promote == 'forge')
+                        <template id="promote-forge">
                             <div class="mt-4 px-3 py-2 border-dashed border-gray-200 border rounded-lg text-xs leading-loose text-gray-700 lg:block dark:border-gray-400 dark:text-gray-200">
                                 <span class="font-medium">Laravel Forge:</span> create and manage PHP 8 servers. Deploy your Laravel applications in seconds. <a class="underline text-red-600" href="https://forge.laravel.com">Sign up now!</a>.
                             </div>
-                        @endif
+                        </template>
 
-                        @if ($promote == 'vapor')
+                        <template id="promote-vapor">
                             <div class="mt-4 px-3 py-2 border-dashed border-gray-200 border rounded-lg text-xs leading-loose text-gray-700 lg:block dark:border-gray-400 dark:text-gray-200">
                                 <span class="font-medium">Laravel Vapor:</span> experience extreme scale on a dedicated serverless platform for Laravel. <a class="underline text-red-600" href="https://vapor.laravel.com">Sign up now!</a>.
                             </div>
-                        @endif
+                        </template>
 
-                        @if ($promote == 'nova')
+                        <template id="promote-nova">
                             <div class="mt-4 px-3 py-2 border-dashed border-gray-200 border rounded-lg text-xs leading-loose text-gray-700 lg:block dark:border-gray-400 dark:text-gray-200">
                                 <span class="font-medium">Laravel Nova:</span> The next generation of Nova is <a class="underline text-red-600" href="https://nova.laravel.com">now available</a>.
                             </div>
-                        @endif
+                        </template>
 
-                        @if ($promote == 'pulse')
+                        <template id="promote-pulse">
                             <div class="mt-4 px-3 py-2 border-dashed border-gray-200 border rounded-lg text-xs leading-loose text-gray-700 lg:block dark:border-gray-400 dark:text-gray-200">
                                 <span class="font-medium">Laravel Pulse:</span> How's your health? Check your application's vital signs using <a href="https://pulse.laravel.com" class="underline text-red-600">Laravel Pulse</a>.
                             </div>
-                        @endif
+                        </template>
 
-                        @if ($promote == 'reverb')
+                        <template id="promote-reverb">
                             <div class="mt-4 px-3 py-2 border-dashed border-gray-200 border rounded-lg text-xs leading-loose text-gray-700 lg:block dark:border-gray-400 dark:text-gray-200">
                                 <span class="font-medium">Laravel Reverb:</span> You can easily build dynamic, real-time Laravel applications using WebSockets. <a href="https://reverb.laravel.com" class="underline text-red-600">Laravel Reverb</a> is now available!
                             </div>
-                        @endif
+                        </template>
+                        <script>
+                            const activePromotionTemplate = document.getElementById(
+                                'promote-'+@js($promotions)[Math.floor(Math.random() * {{ count($promotions) }})]
+                            )
+
+                            activePromotionTemplate.replaceWith(activePromotionTemplate.content)
+                        </script>
                     </div>
                 </div>
             </aside>


### PR DESCRIPTION
With our recent changes to caching, we lost the per-load randomness of the header banner and side bar promotion.

This PR restores the per-load randomness to ensure that the one banner / side bar add is not stuck on each page for an extended period of time and get an equal share of views. It achieves this by pushing the randomness into JavaScript.