### PR TITLE
Loading links as soon as hovered

### DIFF
--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -85,6 +85,7 @@
         navIsOpen: false,
     }"
     class="w-full h-full font-sans antialiased text-gray-900 language-php"
+    data-instant-intensity="0"
 >
 
 @yield('content')


### PR DESCRIPTION
The preloading technique we have employed uses a 65ms delay before loading a link once hovered.

I think we can just preload the link as soon as it is hovered. This seems to be the way most other preloading techniques work and I think we can safely do this on the Laravel docs.

In fact, a lot of other preloading techniques just preload any link as soon as it enters the _viewport_ (which I feel is a little too much - although we can do it).