### PR TITLE
Create LICENSE (very important!)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Taylor Otwell and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
The license field was removed from the composer.json for whatever reason in #309 
It's [very important](https://choosealicense.com/no-permission) we add it back or at least create a LICENSE file. This PR does both. We need a licensing permission from the following people that have contributed after the change before @taylorotwell can merge this:
@timacdonald
@nunomaduro
@jbrooksuk
@driesvints
@joedixon
@utsavsomaiya (maybe we don't need permission as he only changed Laracon AU to IN)
@SjorsO
@pabueco
@jasonlbeggs
Note that some, if not all, of these people are Laravel team members.
The following people also have contributed to the project after the license removal but we may not need their permission as they only did minor changes
@choowx # only fixed incorrect href url
@rainx # only removed .DS_Store
@niekatywny # only removed semicolon where it didn't belong
@caendesilva # only updated Discord url
@mpociot # only re-added Herd to news rotation
@nexxai # only fixed a typo about Laracon
@jakebathman # only added 11.x branch to checkout_latest_docs.sh script
@Jubeki # only removed merch from random values