### PR TITLE
Fix broken input styles and broken buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "laravel-site",
+    "name": "laravel.com",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/views/components/button/primary.blade.php
+++ b/resources/views/components/button/primary.blade.php
@@ -1,7 +1,7 @@
 @props(['href' => null])
 
 @if ($href)
-    <a {{ $attributes->merge(['class' => 'group relative inline-flex border border-red-500 focus:outline-none' ]) }}>
+    <a {{ $attributes->merge(['class' => 'group relative inline-flex border border-red-500 focus:outline-none' ]) }} href={{$href}}>
         <span class="w-full inline-flex items-center justify-center self-stretch px-4 py-2 text-sm text-white text-center font-bold uppercase bg-red-500 ring-1 ring-red-500 ring-offset-1 ring-offset-red-500 transform transition-transform group-hover:-translate-y-1 group-hover:-translate-x-1 group-focus:-translate-y-1 group-focus:-translate-x-1">
             {{ $slot }}
         </span>

--- a/resources/views/components/forms/checkbox.blade.php
+++ b/resources/views/components/forms/checkbox.blade.php
@@ -1,1 +1,1 @@
-<input {{ $attributes->merge(['class' => 'text-red-600 border border-gray-400 focus:outline-none focus:ring-0 focus:border-red-600']) }} type="checkbox">
+<input {{ $attributes->merge(['class' => 'form-checkbox text-red-600 border border-gray-400 focus:outline-none focus:ring-0 focus:border-red-600']) }} type="checkbox">

--- a/resources/views/components/forms/input.blade.php
+++ b/resources/views/components/forms/input.blade.php
@@ -1,3 +1,3 @@
 @props(['type' => 'text'])
 
-<input {{ $attributes->merge(['class' => 'w-full block px-3 py-2 border border-gray-400 sm:text-sm focus:outline-none focus:ring-0 focus:border-red-600 transition']) }} type="{{ $type }}">
+<input {{ $attributes->merge(['class' => 'form-input w-full block px-3 py-2 border border-gray-400 sm:text-sm focus:outline-none focus:ring-0 focus:border-red-600 transition']) }} type="{{ $type }}">

--- a/resources/views/components/forms/textarea.blade.php
+++ b/resources/views/components/forms/textarea.blade.php
@@ -1,1 +1,1 @@
-<textarea {{ $attributes->merge(['class' => 'w-full block px-3 py-2 border border-gray-400 sm:text-sm focus:outline-none focus:ring-0 focus:border-red-600 transition [field-sizing:content]']) }}></textarea>
+<textarea {{ $attributes->merge(['class' => 'form-textarea w-full block px-3 py-2 border border-gray-400 sm:text-sm focus:outline-none focus:ring-0 focus:border-red-600 transition [field-sizing:content]']) }}></textarea>

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -166,7 +166,7 @@
                                     <select
                                         id="version-switcher"
                                         aria-label="Laravel version"
-                                        class="appearance-none flex-1 w-full px-0 py-1 placeholder-gray-900 tracking-wide bg-white focus:outline-none dark:bg-dark-700 dark:text-gray-400 dark:placeholder-gray-500"
+                                        class="appearance-none flex-1 w-full px-0 py-1 placeholder-gray-900 tracking-wide bg-white border-transparent focus:outline-none dark:bg-dark-700 dark:text-gray-400 dark:placeholder-gray-500"
                                         @change="window.location = $event.target.value"
                                     >
                                         @foreach ($versions as $key => $display)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -131,5 +131,9 @@ export default {
         pattern: new RegExp(`bg-(${Object.keys(accentColors).join('|')})`),
     }
   ],
-  plugins: [forms],
+  plugins: [
+    forms({
+        strategy: 'class',
+    })
+  ],
 }


### PR DESCRIPTION
This PR fixes some broken input styles after #358 introduced `@tailwindcss/forms` plugin.

Also fixes all the primay buttons with `href` attributes

**Before**

![CleanShot 2024-09-13 at 20 54 02@2x](https://github.com/user-attachments/assets/97cf0a32-a124-467c-99d7-6b8d9c3a19b1)

![CleanShot 2024-09-13 at 20 55 15@2x](https://github.com/user-attachments/assets/be25725e-60cd-40ab-8fd1-7da6d6da8a5d)

**After**

![CleanShot 2024-09-13 at 20 55 55@2x](https://github.com/user-attachments/assets/c60aa4b7-b57d-44fe-a64a-d475e299e59b)

![CleanShot 2024-09-13 at 20 56 11@2x](https://github.com/user-attachments/assets/98a0c858-5f9c-4f12-8701-811cb78f6fbc)
