### PR TITLE
more obvious and ever-present callout when not on current version

### DIFF
--- a/resources/views/partials/layout.blade.php
+++ b/resources/views/partials/layout.blade.php
@@ -86,7 +86,7 @@
     x-data="{
         navIsOpen: false,
     }"
-    class="w-full h-full font-sans antialiased text-gray-900 language-php"
+    class="w-full h-full font-sans antialiased text-gray-900 language-php {{ version_compare($currentVersion, DEFAULT_VERSION) !== 0 ? 'border-4 border-orange-600' : '' }}"
     data-instant-intensity="0"
 >
 


### PR DESCRIPTION
currently the only thing that indicates a user is not on the current version on the documentation is the version dropdown in the upper right corner, and a callout box, both of which are only visible at the top of the page.

it would be great to have some ever-present visual to indicate to the user they ARE NOT on the current documentation. I know I've had times I've forgotten I had old documentation up.

open to other designs, but this is what I started with.