### PR TITLE
refactor(bin/checkout_lastest_docs.sh): prevent `globbing`

### DIFF
--- a/bin/checkout_latest_docs.sh
+++ b/bin/checkout_latest_docs.sh
@@ -23,7 +23,7 @@ DOCS_VERSIONS=(
 for v in "${DOCS_VERSIONS[@]}"; do
     if [ -d "resources/docs/$v" ]; then
         echo "Pulling latest documentation updates for $v..."
-        (cd resources/docs/$v && git pull)
+        (cd resources/docs/"$v" && git pull)
     else
         echo "Cloning $v..."
         git clone --depth 1 --single-branch --branch "$v" https://github.com/laravel/docs "resources/docs/$v"


### PR DESCRIPTION
I've run: `shellcheck bin/checkout_latest_docs.sh`;

Yhe output was:
`In bin/checkout_latest_docs.sh line 13:
        (cd resources/docs/$v && git pull)
                           ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
        (cd resources/docs/"$v" && git pull)

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
`