### PR TITLE
Fix mobile navigation overlap

### DIFF
--- a/resources/views/partials/header.blade.php
+++ b/resources/views/partials/header.blade.php
@@ -89,7 +89,7 @@
             x-show="navIsOpen"
             x-transition.opacity
             x-cloak
-            class="fixed inset-0 w-full pt-[4.2rem] z-10 pointer-events-none"
+            class="fixed inset-0 w-full pt-28 z-10 pointer-events-none"
         >
             <div class="relative h-full w-full py-8 px-5 bg-white pointer-events-auto overflow-y-auto">
                 <ul>


### PR DESCRIPTION
Fix mobile navigation padding overlap

- Adjusted top padding in mobile navigation menu to prevent overlap between logo and close button
- Previous behaviour caused the logo and close button to collide on mobile devices

Before
![Before](https://github.com/user-attachments/assets/52a90ebe-c33d-4ba1-b33c-96d2ba511828)

After
![After](https://github.com/user-attachments/assets/2ea0be83-8044-4fd2-b305-94e4c0a2243a)
