### PR TITLE
Add llms.txt support

### DIFF
--- a/app/Documentation.php
+++ b/app/Documentation.php
@@ -49,7 +49,9 @@ class Documentation
             $path = base_path('resources/docs/'.$version.'/documentation.md');
 
             if ($this->files->exists($path)) {
-                return $this->replaceLinks($version, (new GithubFlavoredMarkdownConverter())->convert($this->files->get($path)));
+                $content = $this->replaceLinks($version, $this->files->get($path));
+
+                return (new GithubFlavoredMarkdownConverter())->convert($content);
             }
 
             return null;
@@ -91,14 +93,70 @@ class Documentation
             $path = base_path('resources/docs/'.$version.'/'.$page.'.md');
 
             if ($this->files->exists($path)) {
-                $content = $this->files->get($path);
+                $content = $this->replaceLinks($version, $this->files->get($path));
 
-                $content = (new GithubFlavoredMarkdownConverter())->convert($content);
-
-                return $this->replaceLinks($version, $content);
+                return (new GithubFlavoredMarkdownConverter())->convert($content);
             }
 
             return null;
+        });
+    }
+
+    /**
+     * Get Markdown of a specific documentation page.
+     *
+     * @param  string  $version
+     * @param  string  $page
+     * @return string|null
+     */
+    public function getMarkdown($version, $page)
+    {
+        return $this->cache->remember('docs.'.$version.'.'.$page.'.md', 60, function () use ($version, $page) {
+            $path = base_path('resources/docs/'.$version.'/'.$page.'.md');
+
+            if ($this->files->exists($path)) {
+                $content = $this->files->get($path);
+                $content = $this->removeNamedAnchors($content);
+                $content = $this->removeTorchlightAnnotations($content);
+                $content = $this->replaceMarkdownRelativeWithAbsoluteUrls($version, $content);
+
+                if ($page !== 'documentation') {
+                    $content = $this->removeTableOfContents($content);
+                }
+
+                return $content;
+            }
+
+            return null;
+        });
+    }
+
+    /**
+     * Ger Markdown of the index page.
+     *
+     * @param  string  $version
+     * @return string|null
+     */
+    public function getIndexMarkdown($version)
+    {
+        return $this->getMarkdown($version, 'documentation');
+    }
+
+    /**
+     * Get Markdown of all pages combined into one string.
+     *
+     * @param  string  $version
+     * @return string
+     */
+    public function getAllMarkdown($version)
+    {
+        return $this->cache->remember('docs.'.$version.'.md', 60, function () use ($version) {
+            $ignoredFiles = ['documentation.md', 'readme.md', 'license.md'];
+
+            return collect($this->files->files(base_path('resources/docs/'.$version)))
+                ->filter(fn($file) => ! in_array($file->getFilename(), $ignoredFiles, true))
+                ->map(fn($file) => $this->getMarkdown($version, $file->getFilenameWithoutExtension()))
+                ->join(PHP_EOL.PHP_EOL);
         });
     }
 
@@ -150,7 +208,7 @@ class Documentation
      */
     public static function replaceLinks($version, $content)
     {
-        return str_replace('%7B%7Bversion%7D%7D', $version, $content);
+        return str_replace('{{version}}', $version, $content);
     }
 
     /**
@@ -207,5 +265,82 @@ class Documentation
             '5.0' => '5.0',
             '4.2' => '4.2',
         ];
+    }
+
+    /**
+     * Replace relative urls with absolute urls in Markdown, adding .md suffix
+     *
+     * @param  string  $version
+     * @param  string  $content
+     * @return string
+     */
+    private function replaceMarkdownRelativeWithAbsoluteUrls($version, $content)
+    {
+        $content = $this->replaceLinks($version, $content, true);
+        $pattern = '/(!?\[([^\]]*)\]\(([^\)]+)\))/'; // markdown links [text](url)
+
+        return preg_replace_callback($pattern, function ($matches) {
+            $text = $matches[2];
+            $url = url(str($matches[3])->startsWith('/docs') ? $matches[3].'.md' : $matches[3]);
+
+            return "[$text]($url)";
+        }, $content);
+    }
+
+    /**
+     * Remove Table of Contents from Markdown
+     *
+     * @param  string  $content
+     * @return string
+     */
+    private function removeTableOfContents($content)
+    {
+        $lines = explode(PHP_EOL, $content);
+
+        if (count($lines) < 2) {
+            return $content;
+        }
+
+        $header = $lines[0];
+        $secondHeaderIndex = 1;
+
+        foreach ($lines as $index => $line) {
+            if (str_starts_with($line, '## ')) {
+                $secondHeaderIndex = $index;
+                break;
+            }
+        }
+
+        $lines = array_slice($lines, $secondHeaderIndex);
+        array_unshift($lines, $header, '');
+
+        return implode(PHP_EOL, $lines);
+    }
+
+    /**
+     * Remove named anchors such as <a name="introduction"></a>
+     *
+     * @param  string  $content
+     * @return string
+     */
+    private function removeNamedAnchors($content) {
+        return preg_replace('/<a name="[\w-]+"><\/a>/i', '', $content);
+    }
+
+    /**
+     * Remove torchlight annotations comments
+     *
+     * @param  string  $content
+     * @return string
+     */
+    private function removeTorchlightAnnotations($content)
+    {
+        $annotations = ['[tl! add]', '[tl! remove]', '[tl! add:start]', '[tl! add:end]'];
+
+        foreach ($annotations as $annotation) {
+            $content = preg_replace('/'.preg_quote('// '.$annotation, '/').'/', '', $content);
+        }
+
+        return $content;
     }
 }

--- a/resources/views/llms.blade.php
+++ b/resources/views/llms.blade.php
@@ -1,0 +1,3 @@
+Laravel Documentation ({{ $version }} version)
+
+{!! $content !!}

--- a/routes/web.php
+++ b/routes/web.php
@@ -10,6 +10,9 @@ if (! defined('DEFAULT_VERSION')) {
     define('DEFAULT_VERSION', '11.x');
 }
 
+Route::get('llms.txt', [DocsController::class, 'showRootLlmsTxt']);
+Route::get('llms-full.txt', [DocsController::class, 'showRootLlmsFullTxt']);
+
 Route::get('docs', [DocsController::class, 'showRootPage']);
 
 Route::get('docs/cashier', function () {
@@ -28,7 +31,11 @@ Route::get('docs/6.0/{page?}', function ($page = null) {
 });
 
 Route::get('docs/{version}/index.json', [DocsController::class, 'index']);
-Route::get('docs/{version}/{page?}', [DocsController::class, 'show'])->name('docs.version');
+Route::get('docs/{version}/llms.txt', [DocsController::class, 'showLlmsTxt']);
+Route::get('docs/{version}/llms-full.txt', [DocsController::class, 'showLlmsFullTxt']);
+Route::get('docs/{version}/{page?}', [DocsController::class, 'show'])
+    ->name('docs.version')
+    ->where('page', '^(?!\.md$).+(\.md)?$');
 
 Route::redirect('partners', 'https://partners.laravel.com');
 


### PR DESCRIPTION
This PR aims to add support for the [/llms.txt and /llms-full.txt files](https://llmstxt.org/)
Example of other sites implementing this standard: https://llmstxt.site/

There are three main changes:
- every docs page has an optional `.md` suffix, which returns the markdown version of that page (ex. /docs/11.x/artisan.md)
- `/docs/{version}/llms.txt` returns an index of all subpages (basically a sitemap for llms)
- `/docs/{version}/llms-full.txt` returns markdown of all docs pages combined into one

Additionally there are two redirects from the root:
- `/llms.txt -> /docs/{version}/llms.txt`
- `/llms-full.txt -> /docs/{version}/llms-full.txt`

Before markdown is returned it goes through a few changes:
- relative links to /docs are converted to absolute urls ending in `.md` 
- named anchors are removed
- torchlight annotations are removed
- table of contents is removed